### PR TITLE
Modernize UI design with a neon cyberpunk theme

### DIFF
--- a/src/components/DeveloperInfo/DeveloperInfo.module.sass
+++ b/src/components/DeveloperInfo/DeveloperInfo.module.sass
@@ -11,24 +11,36 @@
     padding: 0
 
 .container
-  background: rgba(162,172,207, .25)
+  position: relative
   display: flex
-  border-right: 5px dashed #192561
-  border-left: 5px dashed #192561
-  border-radius: 0 40px 0 40px
-  transition: .3s ease
-  padding: 15px
+  align-items: center
+  gap: 24px
+  padding: 28px
+  background: linear-gradient(165deg, rgba(14, 20, 42, .9) 0%, rgba(5, 8, 20, .94) 100%)
+  backdrop-filter: blur(8px)
+  border: 1px solid rgba(0, 240, 255, .35)
+  border-radius: 14px
+  box-shadow: 0 0 30px rgba(0, 240, 255, .12), inset 0 0 60px rgba(0, 0, 0, .4)
+  transition: transform .3s ease, border-color .3s ease, box-shadow .3s ease
+
+  // неоновая линия-акцент по верхней кромке
+  &::before
+    content: ''
+    position: absolute
+    top: -1px
+    left: 32px
+    right: 32px
+    height: 2px
+    background: linear-gradient(90deg, transparent, rgba(0, 240, 255, .8), transparent)
+
+  &:hover
+    transform: translateY(-4px)
+    border-color: rgba(255, 45, 149, .5)
+    box-shadow: 0 0 36px rgba(255, 45, 149, .2), inset 0 0 60px rgba(0, 0, 0, .4)
 
   @media screen and (max-width: 576px)
     margin: 30px 0
     padding: 15px 5px
-
-  &:hover
-    box-shadow: inset -8px -8px 11px -6px rgba(219, 116, 231, 0.65), inset 8px 8px 11px -6px rgba(219, 116, 231, 0.65), 0 4px 19px 7px rgba(219, 116, 231, 0.65)
-    border: 0 solid #8e3cc5
-    transform: scale(1.05)
-
-  @media screen and (max-width: 576px)
     flex-direction: column
     align-items: center
 
@@ -39,15 +51,12 @@
     flex-basis: 100%
 
   img
-    border-radius: 0 25px 0 25px
+    display: block
     width: 300px
-    margin: 15px
-
-    @media screen and (max-width: 576px)
-      margin: 15px 5px
-
-    @media screen and (min-width: 360px)
-      margin: 0px 5px
+    max-width: 100%
+    border-radius: 10px
+    border: 1px solid rgba(0, 240, 255, .35)
+    box-shadow: 0 0 18px rgba(0, 240, 255, .18)
 
 .info
   flex-basis: 65%
@@ -58,12 +67,27 @@
     max-width: 320px
 
   h1
-    font-family: Consolas, monospace
-    font-size: 2.5rem
-    color: white
-    text-shadow: 0 0 5px #FFF, 0 0 10px #FFF, 0 0 15px #FFF, 0 0 20px #f8f363, 0 0 30px #f8f363, 0 0 40px #49FF18, 0 0 55px #f8f363, 0 0 75px #f8f363
+    margin: 0 0 12px
+    font-family: var(--font-display)
+    font-weight: 400
+    font-size: 2.4rem
+    letter-spacing: .08em
+    color: #eaf6ff
+    text-shadow: 0 0 8px rgba(0, 240, 255, .75), 0 0 28px rgba(0, 240, 255, .35)
 
   p
-    font-family: Consolas, monospace
-    color: black
-    font-size: 1.6rem
+    font-family: var(--font-mono)
+    color: var(--cyber-text)
+    font-size: 1.2rem
+    line-height: 1.5
+
+.socials
+  align-self: flex-end
+
+  p
+    margin: 0
+    font-family: var(--font-mono)
+    font-size: .8rem
+    letter-spacing: .1em
+    text-transform: uppercase
+    color: var(--cyber-text-dim)

--- a/src/components/DeveloperInfo/DeveloperInfo.tsx
+++ b/src/components/DeveloperInfo/DeveloperInfo.tsx
@@ -13,9 +13,9 @@ const DeveloperInfo = () => {
                         <h1 >Vadim Xces</h1 >
                         <p >Немного текста обо мне</p >
                     </div >
-                    <div>
+                    <div className = {classes.socials}>
                         <p>
-                            оциалочки
+                            Социалочки
                         </p>
                     </div>
                 </div >

--- a/src/components/Game/Dialog/Dialog.module.sass
+++ b/src/components/Game/Dialog/Dialog.module.sass
@@ -1,75 +1,112 @@
 .dialogBoxWrapper
   position: absolute
   z-index: 999
-
-  transform: translate(150px, 400px)
-
+  // якорь по центру нижней части поля: (800 - 560) / 2 = 120
+  transform: translate(120px, 610px)
 
 .dialogBox
   position: relative
-  width: 500px
-  height: 150px
+  width: 560px
+  min-height: 160px
+  box-sizing: border-box
   display: grid
-  grid-column-gap: 20px
-  grid-template-rows: 1fr 5fr
-  grid-template-columns: 1fr 3fr
+  grid-column-gap: 18px
+  grid-row-gap: 4px
+  grid-template-rows: auto 1fr
+  padding: 16px 18px 22px
 
-  background: linear-gradient(18deg, rgba(54, 62, 99, 1) 0%, rgba(15, 30, 73, 1) 100%)
-  border: 3px solid white
-  border-radius: 5px
+  background: linear-gradient(165deg, rgba(14, 20, 42, .92) 0%, rgba(5, 8, 20, .96) 100%)
+  backdrop-filter: blur(6px)
+  border: 1px solid var(--accent)
+  border-radius: 10px
+  box-shadow: 0 0 24px var(--glow), inset 0 0 50px rgba(0, 0, 0, .5)
 
+  // неоновая линия-акцент по верхней кромке
+  &::before
+    content: ''
+    position: absolute
+    top: -1px
+    left: 24px
+    right: 24px
+    height: 2px
+    background: linear-gradient(90deg, transparent, var(--accent), transparent)
+
+// цветовые роли говорящих задаются через custom properties
 .hero
-  grid-template-areas: 'a h h' 'a t t'
-
-  .avatar
-    margin-left: 20px
-    justify-self: start
-
-  .text
-    padding-right: 20px
-
+  --accent: rgba(0, 240, 255, .55)
+  --title-color: #7df9ff
+  --glow: rgba(0, 240, 255, .2)
+  grid-template-areas: 'a h' 'a t'
+  grid-template-columns: 118px 1fr
 
 .enemy
-  grid-template-areas: 'h h a' 't t a'
-
-  .avatar
-    margin-right: 20px
-    justify-self: end
-
-  .text
-    padding-left: 20px
+  --accent: rgba(255, 45, 149, .55)
+  --title-color: #ff7ac1
+  --glow: rgba(255, 45, 149, .22)
+  grid-template-areas: 'h a' 't a'
+  grid-template-columns: 1fr 118px
 
 .avatar
   grid-area: a
+  width: 118px
+  height: 118px
+  object-fit: cover
+  border-radius: 8px
+  border: 1px solid var(--accent)
+  box-shadow: 0 0 14px var(--glow)
+  align-self: center
 
 .text
   grid-area: t
-  color: white
+  color: var(--cyber-text)
   width: 100%
-  font-family: Consolas, monospace
-  text-indent: 1.5em
+  font-family: var(--font-mono)
+  font-size: .95rem
+  line-height: 1.5
   word-wrap: break-word
   justify-self: start
 
   p
     margin-block-start: 0
+    margin-block-end: 0
 
 .title
   grid-area: h
-  color: white
+  margin: 0
+  color: var(--title-color)
   width: 100%
-  font-family: Consolas, monospace
-  text-indent: 1.5em
-  margin-block-end: 0.3em
+  font-family: var(--font-mono)
+  font-size: 1rem
+  letter-spacing: .14em
+  text-transform: uppercase
+  text-shadow: 0 0 10px var(--glow)
 
 .cursor
-  color: white
-  background-color: white
+  color: var(--title-color)
+  animation: blink .9s steps(1, jump-none) infinite
 
 .nextPopup
-  right: 10px
-  bottom: 5px
-  font-size: 0.6rem
+  right: 12px
+  bottom: 10px
+  font-size: 0.62rem
+  padding: 3px 9px
+  border: 1px solid rgba(255, 255, 255, .22)
+  border-radius: 4px
+  animation: hintPulse 2.2s ease-in-out infinite
 
   span
-    color: white
+    color: rgba(255, 255, 255, .6)
+    letter-spacing: .08em
+    text-transform: uppercase
+
+@keyframes blink
+  0%, 100%
+    opacity: 1
+  50%
+    opacity: 0
+
+@keyframes hintPulse
+  0%, 100%
+    border-color: rgba(255, 255, 255, .22)
+  50%
+    border-color: var(--accent)

--- a/src/components/Game/Game.module.sass
+++ b/src/components/Game/Game.module.sass
@@ -2,3 +2,12 @@
   height: 800px
   width: 800px
   position: relative
+
+// HUD-рамка поверх поля: неоновые уголки-скобки, клики пропускает
+.hudFrame
+  position: absolute
+  inset: -14px
+  pointer-events: none
+  z-index: 500
+  filter: drop-shadow(0 0 6px rgba(0, 240, 255, .6))
+  background: linear-gradient(var(--cyber-cyan), var(--cyber-cyan)) top left / 30px 2px no-repeat, linear-gradient(var(--cyber-cyan), var(--cyber-cyan)) top left / 2px 30px no-repeat, linear-gradient(var(--cyber-cyan), var(--cyber-cyan)) top right / 30px 2px no-repeat, linear-gradient(var(--cyber-cyan), var(--cyber-cyan)) top right / 2px 30px no-repeat, linear-gradient(var(--cyber-cyan), var(--cyber-cyan)) bottom left / 30px 2px no-repeat, linear-gradient(var(--cyber-cyan), var(--cyber-cyan)) bottom left / 2px 30px no-repeat, linear-gradient(var(--cyber-cyan), var(--cyber-cyan)) bottom right / 30px 2px no-repeat, linear-gradient(var(--cyber-cyan), var(--cyber-cyan)) bottom right / 2px 30px no-repeat

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -15,6 +15,7 @@ const Game = (props: GameProps) => {
         <div className = {classes.gameContainer}>
             <WorldMapContainer />
             <GameObjectsContainer />
+            <div className = {classes.hudFrame} />
             {props.gameMode === GAME_MODES.SPEAKING && <Dialog />}
             {props.gameMode === GAME_MODES.BATTLE && <Battle />}
         </div >

--- a/src/components/Game/WorldMap/WorldMap.module.sass
+++ b/src/components/Game/WorldMap/WorldMap.module.sass
@@ -2,6 +2,7 @@
   position: absolute
   height: 800px
   width: 800px
-  background: black
-  border: 3px solid white
+  background: #05060e
+  border: 1px solid rgba(0, 240, 255, .45)
+  box-shadow: 0 0 28px rgba(0, 240, 255, .18), 0 0 90px rgba(0, 240, 255, .08), inset 0 0 90px rgba(0, 0, 0, .55)
   margin: auto

--- a/src/components/MainMenu/Button/Button.module.sass
+++ b/src/components/MainMenu/Button/Button.module.sass
@@ -6,24 +6,27 @@
   width: 100%
   padding-bottom: 5px
   min-width: 320px
-  transition: transform .2s ease
+  transition: transform .2s ease, filter .2s ease
   background-color: transparent
   border: none
   outline: none
+  cursor: pointer
+  filter: drop-shadow(0 0 6px rgba(0, 240, 255, .35))
 
   &:hover
-    transform: translateY(-5px) scale(1.2)
+    transform: translateY(-4px) scale(1.1)
+    filter: drop-shadow(0 0 12px rgba(255, 45, 149, .45))
 
   p
-    font-family: 'Cyberfunk', fantasy
-    color: white
+    font-family: var(--font-display)
+    color: #eaf6ff
     text-align: center
     font-size: 1.5rem
+    letter-spacing: 0.08em
     text-transform: uppercase
+    text-shadow: 0 0 6px rgba(0, 240, 255, .55), 0 0 18px rgba(0, 240, 255, .25)
     transition: 0.3s ease
     transform: translateY(-4px)
-
-
 
   svg
     position: absolute
@@ -32,8 +35,8 @@
     z-index: 1
 
     path
-      stroke-width: 3
-      stroke: #c8c7d7
+      stroke-width: 2
+      stroke: rgba(0, 240, 255, .8)
       fill: url(#gradient)
       stroke-dasharray: 700
       transition: transform 0.3s linear
@@ -41,18 +44,15 @@
 
     &:hover path
       transition: 0.2s ease
-      //stroke: #f6f543
-      stroke: #966ec3
+      stroke: var(--cyber-magenta)
       animation: circler 3s reverse cubic-bezier(0.45, 0.09, 0.51, 0.95) 0s infinite
       animation-fill-mode: forwards
 
     &:hover + p
       transition: .5s ease
-      //color: #f6f543
-      //text-shadow: #FFF 0 0 3px, #FFF 0 0 8px, #FFF 0 0 12px, #FF2D95 0 0 17px, #FF2D95 0 0 25px, #FF2D95 0 0 40px, #FF2D95 0 0 50px, #FF2D95 0 0 75px
-      text-shadow: -4px 3px 0px #bd56b2, 4px -2px 0px #649cf1
-
-
+      color: #ffffff
+      // хроматический «глитч» текста при наведении
+      text-shadow: -3px 2px 0 rgba(255, 45, 149, .8), 3px -2px 0 rgba(0, 240, 255, .8)
 
 @keyframes circler
   from
@@ -61,6 +61,3 @@
   to
     stroke-dasharray: 700
     stroke-dashoffset: 1400
-
-
-

--- a/src/components/MainMenu/Button/Button.tsx
+++ b/src/components/MainMenu/Button/Button.tsx
@@ -10,9 +10,9 @@ const Button = (props: ButtonProps) => {
                 <svg width="315" height="60" viewBox="0 0 302 62" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <defs>
                         <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                            <stop offset="0%"   stopColor ="rgba(2,0,36,.8) "/>
-                            <stop offset="68%"  stopColor ="rgba(169,132,210,0.2435749299719888)"/>
-                            <stop offset="100%" stopColor ="rgba(2,0,36,.8)"/>
+                            <stop offset="0%"   stopColor ="rgba(3,8,22,.92)"/>
+                            <stop offset="55%"  stopColor ="rgba(0,240,255,.12)"/>
+                            <stop offset="100%" stopColor ="rgba(5,2,26,.92)"/>
                         </linearGradient>
                     </defs>
                     <path d="M118.13 1H7.29888L1 7.07594V48.4684L7.29888 55.6835H189.246L196.173 61H294.997L301 55.6835V12.7722L294.997 7.07594H125.98L118.13 1Z" />

--- a/src/components/MainMenu/Menu.module.sass
+++ b/src/components/MainMenu/Menu.module.sass
@@ -1,20 +1,71 @@
 .menuBackground
     height: 100vh
     display: flex
+    flex-direction: column
     justify-content: center
     align-items: center
+    gap: 8vh
+
+.title
+    position: relative
+    margin: 0
+    font-family: var(--font-display)
+    font-weight: 400
+    font-size: clamp(3rem, 9vw, 5.5rem)
+    letter-spacing: 0.18em
+    text-transform: uppercase
+    color: #eaf6ff
+    text-shadow: 0 0 8px rgba(0, 240, 255, .8), 0 0 24px rgba(0, 240, 255, .45), 0 0 72px rgba(0, 240, 255, .25)
+    animation: flicker 5s linear infinite
+
+    // глитч-слои: хроматические копии заголовка из data-text
+    &::before, &::after
+        content: attr(data-text)
+        position: absolute
+        inset: 0
+        text-shadow: none
+        opacity: 0
+
+    &::before
+        color: var(--cyber-magenta)
+        clip-path: inset(15% 0 55% 0)
+        animation: glitch 3.1s steps(1, jump-none) infinite
+
+    &::after
+        color: var(--cyber-cyan)
+        clip-path: inset(60% 0 10% 0)
+        animation: glitch 2.3s steps(1, jump-none) infinite reverse
 
 .menuContainer
     display: flex
     flex-direction: column
     justify-content: space-around
-    min-height: 400px
-    height: 200px
+    min-height: 320px
 
     @media screen and (min-width: 720px)
-        transform: scale(1.5)
+        transform: scale(1.25)
 
 .menuItem
     text-decoration: none
     &:visited
         text-decoration: none
+
+@keyframes flicker
+    0%, 87%, 91%, 100%
+        opacity: 1
+    88%, 90%
+        opacity: .55
+
+@keyframes glitch
+    0%, 89%, 100%
+        opacity: 0
+        transform: translate(0, 0)
+    90%
+        opacity: .8
+        transform: translate(-4px, 2px)
+    93%
+        opacity: .8
+        transform: translate(4px, -2px)
+    96%
+        opacity: .6
+        transform: translate(-2px, 0)

--- a/src/components/MainMenu/Menu.tsx
+++ b/src/components/MainMenu/Menu.tsx
@@ -16,6 +16,7 @@ const Menu = (props: MenuProps) => {
 
     return (
         <div className = {classes.menuBackground}>
+            <h1 className = {classes.title} data-text = "Crawler">Crawler</h1 >
             <div className = {classes.menuContainer}>
                 {optionsList}
             </div >

--- a/src/components/Preloader/Preloader.module.sass
+++ b/src/components/Preloader/Preloader.module.sass
@@ -1,7 +1,36 @@
 .preloaderContainer
   display: flex
+  flex-direction: column
+  gap: 32px
   justify-content: center
   align-items: center
   height: 100vh
   width: 100vw
-  background-color: #21293f
+  background: radial-gradient(circle at 50% 42%, #0b1226 0%, #05060e 72%)
+
+  img
+    filter: drop-shadow(0 0 18px rgba(240, 45, 255, .45))
+
+.loadingText
+  margin: 0
+  font-family: var(--font-mono)
+  font-size: .85rem
+  letter-spacing: .4em
+  text-transform: uppercase
+  color: #7df9ff
+  text-shadow: 0 0 10px rgba(0, 240, 255, .6)
+
+  // бегущие точки: content анимируется дискретными шагами
+  &::after
+    content: ''
+    animation: dots 1.2s steps(1, jump-none) infinite
+
+@keyframes dots
+  0%
+    content: ''
+  25%
+    content: '.'
+  50%
+    content: '..'
+  75%
+    content: '...'

--- a/src/components/Preloader/Preloader.tsx
+++ b/src/components/Preloader/Preloader.tsx
@@ -16,6 +16,7 @@ const Preloader = () => {
     return (
         <animated.div className = {classes.preloaderContainer} style = {containerStyle}>
             <animated.img src = {preloaderSvg} style = {imageStyle} alt = "Game is loading" />
+            <animated.p className = {classes.loadingText} style = {imageStyle}>Loading</animated.p >
         </animated.div >
     );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,22 @@
 @import "./assets/fonts/CyberfunkImport/Cyberfunk.css";
 
+:root {
+    /* Дизайн-токены киберпанк-палитры — единственный источник цветов UI */
+    --cyber-bg: #05060e;
+    --cyber-cyan: #00f0ff;
+    --cyber-magenta: #ff2d95;
+    --cyber-text: #d7e2f2;
+    --cyber-text-dim: #8fa0bd;
+    --font-display: 'Cyberfunk', Consolas, monospace;
+    --font-mono: 'Cascadia Code', Consolas, 'JetBrains Mono', Menlo, monospace;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
     margin: 0;
+    background-color: var(--cyber-bg);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
@@ -14,18 +26,53 @@ code {
     monospace;
 }
 
+::selection {
+    background: rgba(0, 240, 255, 0.35);
+    color: #fff;
+}
+
 a {
   text-decoration: none !important;
 }
 
 .App {
+    position: relative;
     height: 100vh;
     width: 100vw;
     background: no-repeat center;
     background-size: cover;
 }
 
+/* Затемнение фона + виньетка, чтобы неон читался поверх картинки */
+.App::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(ellipse at 50% 45%, rgba(5, 6, 14, 0.1) 30%, rgba(5, 6, 14, 0.65) 100%),
+        rgba(5, 6, 14, 0.25);
+}
+
+/* CRT-сканлайны поверх всего интерфейса */
+.App::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1000;
+    background: repeating-linear-gradient(
+        0deg,
+        rgba(0, 0, 0, 0.14) 0px,
+        rgba(0, 0, 0, 0.14) 1px,
+        transparent 1px,
+        transparent 3px
+    );
+}
+
 .AppWrapper {
+    position: relative;
+    z-index: 1;
     height: inherit;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Что сделано

Осовременил визуальный стиль всего приложения, сохранив киберпанк-эстетику. Только стили и точечные правки разметки — логика игры не тронута.

### Дизайн-система (`src/index.css`)
- CSS-переменные с палитрой: неоновый циан `#00f0ff`, маджента `#ff2d95`, тёмный фон `#05060e`, шрифты (`--font-display` — Cyberfunk, `--font-mono`)
- CRT-сканлайны поверх всего интерфейса и виньетка, затемняющая фоновую картинку, чтобы неон читался

### Главное меню
- Глитч-заголовок **CRAWLER** (хроматические слои через `data-text`, фликер-анимация)
- Кнопки: неоновая циановая обводка со свечением, тёмная заливка градиента, маджента-глитч при наведении

### Прелоадер
- Тёмный радиальный фон, свечение спиннера, анимированный текст `LOADING...`

### Игровое поле
- Неоновая рамка карты со свечением вместо белой 3px-границы
- HUD-уголки-скобки по углам поля (оверлей, клики пропускает)

### Диалоги
- Стеклянная панель (blur, градиент, неоновая линия по верхней кромке), закреплена внизу поля
- Цветовые роли говорящих через custom properties: циан для героя, маджента для противника (рамка, имя, аватар)
- Аватар с рамкой и свечением, мигающий курсор печати, подсказка «пропустить (Enter)» в виде пульсирующего чипа

### Страница «About developer»
- Стеклянная карточка с неоновыми акцентами вместо пунктирных рамок, читаемые цвета текста (был чёрный на тёмном), поправлен обрезанный текст «оциалочки»

## Проверки
- `tsc --noEmit` — чисто; `vite build` — успешно (CSS 9.82 kB gzip 2.98 kB)
- Playwright: полный цикл диалога (открытие → 11 фраз → закрытие → одноразовость), блокировка ходов в стены, меню/прелоадер/страница About — все проверки зелёные, ошибок в консоли нет
- Скриншоты всех экранов сняты до/после

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi)_