### PR TITLE
Add ESLint and Prettier with CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,35 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
-  pull_request:
+    push:
+        branches: [master]
+    pull_request:
 
 jobs:
-  check:
-    name: Typecheck & Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    check:
+        name: Lint, Typecheck & Build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: npm
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Typecheck
-        run: npm run typecheck
+            - name: Lint
+              run: npm run lint
 
-      - name: Build
-        run: npx vite build
+            - name: Check formatting
+              run: npm run format:check
+
+            - name: Typecheck
+              run: npm run typecheck
+
+            - name: Build
+              run: npx vite build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Prettier не поддерживает indented-синтаксис .sass
+*.sass
+dist/
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+    "singleQuote": true,
+    "tabWidth": 4,
+    "semi": true,
+    "printWidth": 100,
+    "trailingComma": "all"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```sh
-npm install        # Node >= 20.19 required (.nvmrc pins 22)
-npm start          # dev server with HMR at http://localhost:3000 (alias: npm run dev)
-npm run typecheck  # tsc --noEmit (Vite only transpiles, it does not check types)
-npm run build      # typecheck + production build to dist/
-npm run preview    # serve the production build locally
+npm install           # Node >= 20.19 required (.nvmrc pins 22)
+npm start             # dev server with HMR at http://localhost:3000 (alias: npm run dev)
+npm run lint          # eslint . --max-warnings 0 (flat config in eslint.config.js)
+npm run format        # prettier --write . (.sass files are NOT formatted — indented syntax is unsupported)
+npm run format:check  # prettier --check .
+npm run typecheck     # tsc --noEmit (Vite only transpiles, it does not check types)
+npm run build         # typecheck + production build to dist/
+npm run preview       # serve the production build locally
 ```
 
-There is no test runner or linter configured. CI (`.github/workflows/ci.yml`) runs typecheck + build on every push to master and on pull requests.
+There is no test runner configured. CI (`.github/workflows/ci.yml`) runs lint + format check + typecheck + build on every push to master and on pull requests. Code style is enforced by Prettier (4-space indent, single quotes, trailing commas); ESLint layers typescript-eslint recommended plus react-hooks and react-refresh rules (unused args/vars are allowed only with a `_` prefix).
 
 ## Overview
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+    { ignores: ['dist'] },
+    {
+        files: ['**/*.{ts,tsx}'],
+        extends: [js.configs.recommended, ...tseslint.configs.recommended, prettier],
+        plugins: {
+            'react-hooks': reactHooks,
+            'react-refresh': reactRefresh,
+        },
+        rules: {
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+            ],
+            'react-hooks/rules-of-hooks': 'error',
+            'react-hooks/exhaustive-deps': 'warn',
+            'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+        },
+        languageOptions: {
+            ecmaVersion: 2022,
+            globals: globals.browser,
+        },
+    },
+);

--- a/index.html
+++ b/index.html
@@ -1,17 +1,17 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Crawler game" />
-    <link rel="manifest" href="/manifest.json" />
-    <title>Crawler Game</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" href="/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <meta name="description" content="Crawler game" />
+        <link rel="manifest" href="/manifest.json" />
+        <title>Crawler Game</title>
+    </head>
+    <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,16 +15,264 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
+        "eslint": "^10.6.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.3",
+        "globals": "^17.7.0",
+        "prettier": "^3.9.4",
         "sass": "^1.101.0",
         "typescript": "^6.0.3",
+        "typescript-eslint": "^8.62.1",
         "vite": "^8.1.3"
       },
       "engines": {
         "node": ">=20.19"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -59,6 +307,250 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -748,6 +1240,27 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
@@ -778,6 +1291,249 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
@@ -804,6 +1560,137 @@
         }
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -820,6 +1707,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -833,10 +1727,50 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -848,6 +1782,258 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.387",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -867,6 +2053,57 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -882,6 +2119,69 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
@@ -889,13 +2189,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -906,12 +2215,96 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -1175,6 +2568,55 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -1194,6 +2636,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -1201,6 +2650,86 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1249,6 +2778,42 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -1385,11 +2950,44 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1418,6 +3016,19 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1425,6 +3036,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -1440,12 +3064,77 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.1.3",
@@ -1523,6 +3212,75 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -1,32 +1,43 @@
 {
-  "name": "crawler-game",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "engines": {
-    "node": ">=20.19"
-  },
-  "dependencies": {
-    "@react-spring/web": "^10.1.2",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "react-router-dom": "^7.18.1",
-    "zustand": "^5.0.14"
-  },
-  "devDependencies": {
-    "@types/node": "^26.1.0",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.3",
-    "sass": "^1.101.0",
-    "typescript": "^6.0.3",
-    "vite": "^8.1.3"
-  },
-  "scripts": {
-    "start": "vite",
-    "dev": "vite",
-    "build": "tsc --noEmit && vite build",
-    "typecheck": "tsc --noEmit",
-    "preview": "vite preview"
-  }
+    "name": "crawler-game",
+    "version": "0.1.0",
+    "private": true,
+    "type": "module",
+    "engines": {
+        "node": ">=20.19"
+    },
+    "dependencies": {
+        "@react-spring/web": "^10.1.2",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router-dom": "^7.18.1",
+        "zustand": "^5.0.14"
+    },
+    "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@types/node": "^26.1.0",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.3",
+        "eslint": "^10.6.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.3",
+        "globals": "^17.7.0",
+        "prettier": "^3.9.4",
+        "sass": "^1.101.0",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.62.1",
+        "vite": "^8.1.3"
+    },
+    "scripts": {
+        "start": "vite",
+        "dev": "vite",
+        "build": "tsc --noEmit && vite build",
+        "typecheck": "tsc --noEmit",
+        "preview": "vite preview",
+        "lint": "eslint . --max-warnings 0",
+        "format": "prettier --write .",
+        "format:check": "prettier --check ."
+    }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,15 +1,15 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    }
-  ],
-  "start_url": ".",
-  "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+    "short_name": "React App",
+    "name": "Create React App Sample",
+    "icons": [
+        {
+            "src": "favicon.ico",
+            "sizes": "64x64 32x32 24x24 16x16",
+            "type": "image/x-icon"
+        }
+    ],
+    "start_url": ".",
+    "display": "standalone",
+    "theme_color": "#000000",
+    "background_color": "#ffffff"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,26 +12,26 @@ interface AppProps {
 
 const App = (props: AppProps) => {
     const appStyle = {
-        backgroundImage: `url('${props.backgroundImageUrl}')`
+        backgroundImage: `url('${props.backgroundImageUrl}')`,
     };
 
-    const content = props.isLoading
-        ? <Preloader />
-        : (<Routes >
-            <Route path = "/" element = {<MenuContainer />} />
-            <Route path = "/game" element = {<GameContainer />} />
-            <Route path = "/character" element = {<PlayerInfoContainer />} />
-            <Route path = "/about" element = {<DeveloperInfoContainer />} />
-        </Routes >);
+    const content = props.isLoading ? (
+        <Preloader />
+    ) : (
+        <Routes>
+            <Route path="/" element={<MenuContainer />} />
+            <Route path="/game" element={<GameContainer />} />
+            <Route path="/character" element={<PlayerInfoContainer />} />
+            <Route path="/about" element={<DeveloperInfoContainer />} />
+        </Routes>
+    );
 
     return (
-        <BrowserRouter >
-            <div className = "App" style = {appStyle}>
-                <div className = "AppWrapper">
-                    {content}
-                </div >
-            </div >
-        </BrowserRouter >
+        <BrowserRouter>
+            <div className="App" style={appStyle}>
+                <div className="AppWrapper">{content}</div>
+            </div>
+        </BrowserRouter>
     );
 };
 

--- a/src/AppContainer.tsx
+++ b/src/AppContainer.tsx
@@ -5,23 +5,20 @@ import App from './App';
 import bgImageBlured from './assets/img/MenuBackground_blured.jpeg';
 
 const AppContainer = () => {
-    const isLoading = useCommonAppStore(state => state.isLoading);
-    const backgroundImageUrl = useCommonAppStore(state => state.backgroundImageUrl);
+    const isLoading = useCommonAppStore((state) => state.isLoading);
+    const backgroundImageUrl = useCommonAppStore((state) => state.backgroundImageUrl);
 
     useEffect(() => {
-        const {changeBackgroundImage, switchPreloader} = useCommonAppStore.getState();
+        const { changeBackgroundImage, switchPreloader } = useCommonAppStore.getState();
         changeBackgroundImage(bgImageBlured);
         switchPreloader(true);
-        const timeoutId = setTimeout(
-            () => {
-                switchPreloader(false);
-            }
-            , 2000
-        );
+        const timeoutId = setTimeout(() => {
+            switchPreloader(false);
+        }, 2000);
         return () => clearTimeout(timeoutId);
     }, []);
 
-    return <App isLoading = {isLoading} backgroundImageUrl = {backgroundImageUrl} />;
+    return <App isLoading={isLoading} backgroundImageUrl={backgroundImageUrl} />;
 };
 
 export default AppContainer;

--- a/src/assets/fonts/CyberfunkImport/Cyberfunk.css
+++ b/src/assets/fonts/CyberfunkImport/Cyberfunk.css
@@ -1,9 +1,11 @@
 @font-face {
-    font-family: "Cyberfunk";
-    src: url("20a15dae14a6505716c6e41e71fb7d7e.eot"); /* IE9*/
-    src: url("20a15dae14a6505716c6e41e71fb7d7e.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-    url("20a15dae14a6505716c6e41e71fb7d7e.woff2") format("woff2"), /* chrome、firefox */
-    url("20a15dae14a6505716c6e41e71fb7d7e.woff") format("woff"), /* chrome、firefox */
-    url("20a15dae14a6505716c6e41e71fb7d7e.ttf") format("truetype"), /* chrome、firefox、opera、Safari, Android, iOS 4.2+*/
-    url("20a15dae14a6505716c6e41e71fb7d7e.svg#Cyberfunk") format("svg"); /* iOS 4.1- */
+    font-family: 'Cyberfunk';
+    src: url('20a15dae14a6505716c6e41e71fb7d7e.eot'); /* IE9*/
+    src:
+        url('20a15dae14a6505716c6e41e71fb7d7e.eot?#iefix') format('embedded-opentype'),
+        /* IE6-IE8 */ url('20a15dae14a6505716c6e41e71fb7d7e.woff2') format('woff2'),
+        /* chrome、firefox */ url('20a15dae14a6505716c6e41e71fb7d7e.woff') format('woff'),
+        /* chrome、firefox */ url('20a15dae14a6505716c6e41e71fb7d7e.ttf') format('truetype'),
+        /* chrome、firefox、opera、Safari, Android, iOS 4.2+*/
+            url('20a15dae14a6505716c6e41e71fb7d7e.svg#Cyberfunk') format('svg'); /* iOS 4.1- */
 }

--- a/src/components/Battle/Battle.tsx
+++ b/src/components/Battle/Battle.tsx
@@ -4,8 +4,8 @@ import BattleMenu from './BattleMenu/BattleMenu';
 const Battle = () => {
     return (
         <>
-            <BattleLayout/>
-            <BattleMenu/>
+            <BattleLayout />
+            <BattleMenu />
         </>
     );
 };

--- a/src/components/Battle/BattleLayout.tsx
+++ b/src/components/Battle/BattleLayout.tsx
@@ -1,9 +1,5 @@
 const BattleLayout = () => {
-    return (
-        <div >
-
-        </div >
-    );
+    return <div></div>;
 };
 
 export default BattleLayout;

--- a/src/components/Battle/BattleMenu/BattleMenu.tsx
+++ b/src/components/Battle/BattleMenu/BattleMenu.tsx
@@ -2,9 +2,9 @@ import HeroBar from './HeroBar/HeroBar';
 
 const BattleMenu = () => {
     return (
-        <div >
-            <HeroBar/>
-        </div >
+        <div>
+            <HeroBar />
+        </div>
     );
 };
 

--- a/src/components/Battle/BattleMenu/HeroBar/HeroBar.tsx
+++ b/src/components/Battle/BattleMenu/HeroBar/HeroBar.tsx
@@ -2,16 +2,16 @@ import ProgressBar from './ProgressBar';
 
 const HeroBar = () => {
     return (
-        <div >
+        <div>
             <div className="">
                 <h3>NAME</h3>
                 <span>63/100</span>
             </div>
             <div>
-                <ProgressBar color={''} percent={50}/>
-                <ProgressBar color={''} percent={50}/>
+                <ProgressBar color={''} percent={50} />
+                <ProgressBar color={''} percent={50} />
             </div>
-        </div >
+        </div>
     );
 };
 

--- a/src/components/Battle/BattleMenu/HeroBar/ProgressBar.tsx
+++ b/src/components/Battle/BattleMenu/HeroBar/ProgressBar.tsx
@@ -5,11 +5,7 @@ interface ProgressBarProps {
 }
 
 const ProgressBar = (_props: ProgressBarProps) => {
-    return (
-        <div className="progressBar">
-
-        </div >
-    );
+    return <div className="progressBar"></div>;
 };
 
 export default ProgressBar;

--- a/src/components/DeveloperInfo/DeveloperInfo.tsx
+++ b/src/components/DeveloperInfo/DeveloperInfo.tsx
@@ -3,24 +3,22 @@ import developerPhoto from '../../assets/img/Developer_Photo.jpg';
 
 const DeveloperInfo = () => {
     return (
-        <div className = {classes.background}>
+        <div className={classes.background}>
             <div className={classes.padder}>
-                <div className = {classes.container}>
-                    <div className = {classes.avatar}>
-                        <img src = {developerPhoto} alt = "photo developer" />
-                    </div >
-                    <div className = {classes.info}>
-                        <h1 >Vadim Xces</h1 >
-                        <p >Немного текста обо мне</p >
-                    </div >
-                    <div className = {classes.socials}>
-                        <p>
-                            Социалочки
-                        </p>
+                <div className={classes.container}>
+                    <div className={classes.avatar}>
+                        <img src={developerPhoto} alt="photo developer" />
                     </div>
-                </div >
-            </div >
-        </div >
+                    <div className={classes.info}>
+                        <h1>Vadim Xces</h1>
+                        <p>Немного текста обо мне</p>
+                    </div>
+                    <div className={classes.socials}>
+                        <p>Социалочки</p>
+                    </div>
+                </div>
+            </div>
+        </div>
     );
 };
 

--- a/src/components/DeveloperInfo/DeveloperInfoContainer.tsx
+++ b/src/components/DeveloperInfo/DeveloperInfoContainer.tsx
@@ -2,16 +2,14 @@ import { useEffect } from 'react';
 import DeveloperInfo from './DeveloperInfo';
 import { useCommonAppStore } from '../../stores/commonAppStore';
 
-import bgImage from '../../assets/img/MenuBackground.jpeg'
+import bgImage from '../../assets/img/MenuBackground.jpeg';
 
 const DeveloperInfoContainer = () => {
     useEffect(() => {
         useCommonAppStore.getState().changeBackgroundImage(bgImage);
     }, []);
 
-    return (
-        <DeveloperInfo/>
-    );
+    return <DeveloperInfo />;
 };
 
 export default DeveloperInfoContainer;

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,9 +1,5 @@
 const Footer = () => {
-    return (
-        <div>
-
-        </div>
-    )
+    return <div></div>;
 };
 
 export default Footer;

--- a/src/components/Game/Dialog/Dialog.tsx
+++ b/src/components/Game/Dialog/Dialog.tsx
@@ -12,49 +12,50 @@ interface AnimatedBoxProps {
 }
 
 const Dialog = () => {
-    const currentDialogId = useDialogsStore(state => state.currentDialogId);
-    const currDialogData = useDialogsStore(state => state.dialogList[state.currentDialogId]);
-    const speakersData = useDialogsStore(state => state.speakersData);
-    const typing = useDialogsStore(state => state.typing);
+    const currentDialogId = useDialogsStore((state) => state.currentDialogId);
+    const currDialogData = useDialogsStore((state) => state.dialogList[state.currentDialogId]);
+    const speakersData = useDialogsStore((state) => state.speakersData);
+    const typing = useDialogsStore((state) => state.typing);
 
     const phrasesCount = currDialogData?.phrases.length ?? 0;
 
     const getBoxes = useMemo(() => {
-      if (!currDialogData) {
-          return [];
-      }
-      return currDialogData.phrases.map((p) => {
-        const speakerData = speakersData.find(char => char.name === p.speaker);
-        const boxRole = speakerData?.role === SPEAKER_ROLES.HERO ? classes.hero : classes.enemy;
-        const spriteSrc = speakerData?.sprite ?? '';
-        return (
-          ({ style }: AnimatedBoxProps) => (
-            <animated.div style={{ ...style, position: 'absolute' }}>
-              <DialogBox
-                boxRole={boxRole}
-                spriteSrc={spriteSrc}
-                text={p.text}
-                speaker={p.speaker}
-              />
-            </animated.div >
-          )
-        );
-      });
-    }, [currDialogData, speakersData])
+        if (!currDialogData) {
+            return [];
+        }
+        return currDialogData.phrases.map((p) => {
+            const speakerData = speakersData.find((char) => char.name === p.speaker);
+            const boxRole = speakerData?.role === SPEAKER_ROLES.HERO ? classes.hero : classes.enemy;
+            const spriteSrc = speakerData?.sprite ?? '';
+            return ({ style }: AnimatedBoxProps) => (
+                <animated.div style={{ ...style, position: 'absolute' }}>
+                    <DialogBox
+                        boxRole={boxRole}
+                        spriteSrc={spriteSrc}
+                        text={p.text}
+                        speaker={p.speaker}
+                    />
+                </animated.div>
+            );
+        });
+    }, [currDialogData, speakersData]);
 
     const [index, setIndex] = useState(0);
 
-    const handleEnterKeydown = useCallback((e: KeyboardEvent) => {
-        if (e.key === 'Enter' && !typing) {
-            if (index < phrasesCount - 1) {
-                useDialogsStore.getState().setTyping(true);
-                setIndex(index + 1);
-            } else {
-                useGameStore.getState().setGameMode(GAME_MODES.EXPLORING);
-                useDialogsStore.getState().addReadDialog(currentDialogId);
+    const handleEnterKeydown = useCallback(
+        (e: KeyboardEvent) => {
+            if (e.key === 'Enter' && !typing) {
+                if (index < phrasesCount - 1) {
+                    useDialogsStore.getState().setTyping(true);
+                    setIndex(index + 1);
+                } else {
+                    useGameStore.getState().setGameMode(GAME_MODES.EXPLORING);
+                    useDialogsStore.getState().addReadDialog(currentDialogId);
+                }
             }
-        }
-    }, [currentDialogId, typing, index, phrasesCount]);
+        },
+        [currentDialogId, typing, index, phrasesCount],
+    );
 
     useEffect(() => {
         window.addEventListener('keydown', handleEnterKeydown);
@@ -65,22 +66,19 @@ const Dialog = () => {
     }, [handleEnterKeydown]);
 
     const transitions = useTransition(index, {
-        from: {opacity: 0, transform: 'translateY(100%)'},
-        enter: {opacity: 1, transform: 'translateY(0)'},
-        leave: {opacity: 0, transform: 'translateY(-50%)'},
+        from: { opacity: 0, transform: 'translateY(100%)' },
+        enter: { opacity: 1, transform: 'translateY(0)' },
+        leave: { opacity: 0, transform: 'translateY(-50%)' },
     });
 
     return (
-        <div className = {classes.dialogBoxWrapper}>
+        <div className={classes.dialogBoxWrapper}>
             {transitions((style, item) => {
-                    const D = getBoxes[item];
-                    return D ? <D style = {style as unknown as React.CSSProperties} /> : null;
-                }
-            )}
-        </div >
+                const D = getBoxes[item];
+                return D ? <D style={style as unknown as React.CSSProperties} /> : null;
+            })}
+        </div>
     );
-
-
 };
 
 export default Dialog;

--- a/src/components/Game/Dialog/DialogBox.tsx
+++ b/src/components/Game/Dialog/DialogBox.tsx
@@ -12,55 +12,61 @@ interface DialogBoxProps {
 }
 
 const DialogBox = (props: DialogBoxProps) => {
+    const typing = useDialogsStore((state) => state.typing);
 
-    const typing = useDialogsStore(state => state.typing);
-
-    const handleEnterKeydown = useCallback((e: KeyboardEvent) => {
-        if (e.key === 'Enter' && typing) {
-            useDialogsStore.getState().setTyping(false);
-        }
-    },[typing]);
-
+    const handleEnterKeydown = useCallback(
+        (e: KeyboardEvent) => {
+            if (e.key === 'Enter' && typing) {
+                useDialogsStore.getState().setTyping(false);
+            }
+        },
+        [typing],
+    );
 
     useEffect(() => {
         window.addEventListener('keydown', handleEnterKeydown);
         return () => {
             window.removeEventListener('keydown', handleEnterKeydown);
         };
-    },[handleEnterKeydown]);
+    }, [handleEnterKeydown]);
 
-  const getTypingContent = useMemo(() => {
-    return typing ?
-      <TypingText className={classes.text}
-        cursorClassName={classes.cursor}
-        speed={3}
-        startDelay={700}
-        text={props.text}
-        onFinishedTyping={() => { useDialogsStore.getState().setTyping(false) }}
-      />
-      :
-      <div className={classes.text}>
-        <p >
-          {props.text}
-        </p >
-      </div>
-  }, [typing]);
+    const getTypingContent = useMemo(() => {
+        return typing ? (
+            <TypingText
+                className={classes.text}
+                cursorClassName={classes.cursor}
+                speed={3}
+                startDelay={700}
+                text={props.text}
+                onFinishedTyping={() => {
+                    useDialogsStore.getState().setTyping(false);
+                }}
+            />
+        ) : (
+            <div className={classes.text}>
+                <p>{props.text}</p>
+            </div>
+        );
+    }, [typing, props.text]);
 
     const nextPopupStyle = useSpring({
-        from: {opacity: 0},
-        to: {opacity: 1},
+        from: { opacity: 0 },
+        to: { opacity: 1 },
         delay: 1300,
     });
 
     return (
-        <div className = {[classes.dialogBox, props.boxRole].join(' ')}>
-            <img className = {classes.avatar} src = {props.spriteSrc} alt = "" />
-            <h3 className = {classes.title}>{props.speaker}</h3 >
-                {getTypingContent}
-            <animated.div style = {{position: 'absolute', ...nextPopupStyle}} className = {classes.nextPopup}>
-                <span >пропустить (Enter) </span >
-            </animated.div >
-        </div >
+        <div className={[classes.dialogBox, props.boxRole].join(' ')}>
+            <img className={classes.avatar} src={props.spriteSrc} alt="" />
+            <h3 className={classes.title}>{props.speaker}</h3>
+            {getTypingContent}
+            <animated.div
+                style={{ position: 'absolute', ...nextPopupStyle }}
+                className={classes.nextPopup}
+            >
+                <span>пропустить (Enter) </span>
+            </animated.div>
+        </div>
     );
 };
 

--- a/src/components/Game/Dialog/TypingText.tsx
+++ b/src/components/Game/Dialog/TypingText.tsx
@@ -16,7 +16,14 @@ interface TypingTextProps {
 /**
  * Печатает текст посимвольно (замена заброшенной react-typing-animation).
  */
-const TypingText = ({text, speed = 50, startDelay = 0, onFinishedTyping, className, cursorClassName}: TypingTextProps) => {
+const TypingText = ({
+    text,
+    speed = 50,
+    startDelay = 0,
+    onFinishedTyping,
+    className,
+    cursorClassName,
+}: TypingTextProps) => {
     const [visibleCount, setVisibleCount] = useState(0);
     const isFinished = visibleCount >= text.length;
 
@@ -28,7 +35,7 @@ const TypingText = ({text, speed = 50, startDelay = 0, onFinishedTyping, classNa
         let intervalId: ReturnType<typeof setInterval> | undefined;
         const timeoutId = setTimeout(() => {
             intervalId = setInterval(() => {
-                setVisibleCount(prev => {
+                setVisibleCount((prev) => {
                     if (prev >= text.length) {
                         clearInterval(intervalId);
                         return prev;
@@ -51,12 +58,12 @@ const TypingText = ({text, speed = 50, startDelay = 0, onFinishedTyping, classNa
     }, [isFinished]);
 
     return (
-        <div className = {className}>
-            <p >
+        <div className={className}>
+            <p>
                 {text.slice(0, visibleCount)}
-                {!isFinished && <span className = {cursorClassName}>|</span >}
-            </p >
-        </div >
+                {!isFinished && <span className={cursorClassName}>|</span>}
+            </p>
+        </div>
     );
 };
 

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -12,13 +12,13 @@ interface GameProps {
 
 const Game = (props: GameProps) => {
     return (
-        <div className = {classes.gameContainer}>
+        <div className={classes.gameContainer}>
             <WorldMapContainer />
             <GameObjectsContainer />
-            <div className = {classes.hudFrame} />
+            <div className={classes.hudFrame} />
             {props.gameMode === GAME_MODES.SPEAKING && <Dialog />}
             {props.gameMode === GAME_MODES.BATTLE && <Battle />}
-        </div >
+        </div>
     );
 };
 

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -7,11 +7,11 @@ import { useGameStore } from '../../stores/gameStore';
 import { useDialogsStore } from '../../stores/dialogsStore';
 
 const GameContainer = () => {
-    const gameMode = useGameStore(state => state.gameMode);
+    const gameMode = useGameStore((state) => state.gameMode);
 
     // загрузка текущего уровня при входе на игровой экран
     useEffect(() => {
-        const {level, loadLevel} = useGameStore.getState();
+        const { level, loadLevel } = useGameStore.getState();
         const levelData = LEVELS[level];
         loadLevel(levelData);
         useDialogsStore.getState().loadDialogs(levelData.dialogs);
@@ -23,22 +23,24 @@ const GameContainer = () => {
         let idleAnimate = false;
 
         const move = (direction: (typeof KEY_TO_DIRECTION)[string]) => {
-            const {level, gameObjects, setGameMode, setGameObjects} = useGameStore.getState();
+            const { level, gameObjects, setGameMode, setGameObjects } = useGameStore.getState();
 
             // обновить данные по всем игровым объектам на уровне
             const updatedGameObjects = getUpdatedGameObjects(
                 gameObjects,
-                {type: 'move', direction},
-                LEVELS[level]
+                { type: 'move', direction },
+                LEVELS[level],
             );
 
             const event = checkOnGameEvent(updatedGameObjects.newGameObjects);
-            const {alreadyReadIndexes, setCurrentDialog} = useDialogsStore.getState();
-            if (event.isGameEvent &&
+            const { alreadyReadIndexes, setCurrentDialog } = useDialogsStore.getState();
+            if (
+                event.isGameEvent &&
                 event.eventObject !== null &&
                 event.eventObject.type === OBJECT_TYPES.DIALOG &&
                 event.eventObject.dialogId !== undefined &&
-                !alreadyReadIndexes.includes(event.eventObject.dialogId)) {
+                !alreadyReadIndexes.includes(event.eventObject.dialogId)
+            ) {
                 setGameMode(GAME_MODES.SPEAKING);
                 setCurrentDialog(event.eventObject.dialogId);
             }
@@ -47,7 +49,11 @@ const GameContainer = () => {
 
         const handleKeydown = (e: KeyboardEvent) => {
             const direction = KEY_TO_DIRECTION[e.key];
-            if (!direction || idleAnimate || useGameStore.getState().gameMode !== GAME_MODES.EXPLORING) {
+            if (
+                !direction ||
+                idleAnimate ||
+                useGameStore.getState().gameMode !== GAME_MODES.EXPLORING
+            ) {
                 return;
             }
             idleAnimate = true;
@@ -62,7 +68,7 @@ const GameContainer = () => {
         return () => window.removeEventListener('keydown', handleKeydown);
     }, []);
 
-    return <Game gameMode = {gameMode} />;
+    return <Game gameMode={gameMode} />;
 };
 
 export default GameContainer;

--- a/src/components/Game/GameObjects/GameObject.tsx
+++ b/src/components/Game/GameObjects/GameObject.tsx
@@ -9,19 +9,15 @@ interface GameObjectProps {
 const GameObject = (props: GameObjectProps) => {
     const spriteControl = {
         position: 'absolute',
-        transform: `translate(${props.position[0]+3}px, ${props.position[1] - 10}px)`,
+        transform: `translate(${props.position[0] + 3}px, ${props.position[1] - 10}px)`,
         backgroundImage: `url('${props.sprite}')`,
         backgroundPosition: `left -${props.spritePosition[0]}px top -${props.spritePosition[1]}px`,
         width: `${props.width}px`,
         height: `${props.height}px`,
-        transition: 'transform .3s cubic-bezier(.74,.28,.6,1.04)'
+        transition: 'transform .3s cubic-bezier(.74,.28,.6,1.04)',
     } as const;
 
-    return (
-        <div className="GameSprite" style = {spriteControl}>
-
-        </div >
-    );
+    return <div className="GameSprite" style={spriteControl}></div>;
 };
 
 export default GameObject;

--- a/src/components/Game/GameObjects/GameObjectsContainer.tsx
+++ b/src/components/Game/GameObjects/GameObjectsContainer.tsx
@@ -21,21 +21,23 @@ const getScreenPosition = (gameObject: GameObjectData, spriteSize: number): [num
 };
 
 const GameObjectsContainer = () => {
-    const gameObjects = useGameStore(state => state.gameObjects);
+    const gameObjects = useGameStore((state) => state.gameObjects);
 
     // объекты без спрайта (триггеры диалогов, заглушки) не рендерим
     return (
         <>
-            {gameObjects.filter(obj => obj.sprite).map(obj => (
-                <GameObject
-                    position = {getScreenPosition(obj, CONSTANTS.SPRITE_SIZE)}
-                    width = {CONSTANTS.SPRITE_SIZE}
-                    height = {CONSTANTS.SPRITE_SIZE}
-                    key = {obj.id}
-                    sprite = {obj.sprite}
-                    spritePosition = {getSpritePosition(obj, CONSTANTS.SPRITE_SIZE)}
-                />
-            ))}
+            {gameObjects
+                .filter((obj) => obj.sprite)
+                .map((obj) => (
+                    <GameObject
+                        position={getScreenPosition(obj, CONSTANTS.SPRITE_SIZE)}
+                        width={CONSTANTS.SPRITE_SIZE}
+                        height={CONSTANTS.SPRITE_SIZE}
+                        key={obj.id}
+                        sprite={obj.sprite}
+                        spritePosition={getSpritePosition(obj, CONSTANTS.SPRITE_SIZE)}
+                    />
+                ))}
         </>
     );
 };

--- a/src/components/Game/WorldMap/WorldMap.tsx
+++ b/src/components/Game/WorldMap/WorldMap.tsx
@@ -10,75 +10,62 @@ interface TileProps {
 }
 
 const Tile = (props: TileProps) => {
-
-    const styles = props.asset !== undefined ? {
-            transform: `translate(${Math.round(props.Xid * props.asset.sizeX) + props.fixLeft}px,
+    const styles =
+        props.asset !== undefined
+            ? {
+                  transform: `translate(${Math.round(props.Xid * props.asset.sizeX) + props.fixLeft}px,
                                   ${Math.round(props.Yid * props.asset.sizeY) + props.fixTop}px)`,
-            backgroundColor: '#21214a',
-            backgroundImage: `url('${props.asset.bgUrl}')`,
-            backgroundPosition: `left -${props.asset.left}px top -${props.asset.top}px`,
-            width: `${props.asset.sizeX}px`,
-            height: `${props.asset.sizeY}px`,
-        }
-        :
-        {};
+                  backgroundColor: '#21214a',
+                  backgroundImage: `url('${props.asset.bgUrl}')`,
+                  backgroundPosition: `left -${props.asset.left}px top -${props.asset.top}px`,
+                  width: `${props.asset.sizeX}px`,
+                  height: `${props.asset.sizeY}px`,
+              }
+            : {};
 
-    return (
-        <div className = "GameSprite"
-             style = {styles}
-        >
-        </div >
-    );
+    return <div className="GameSprite" style={styles}></div>;
 };
 
 interface RowMapProps {
     id: number;
     row: number[];
     mapAssets: Record<number, TileAsset>;
-    constants: {FIX_TOP: number; FIX_LEFT: number};
+    constants: { FIX_TOP: number; FIX_LEFT: number };
 }
 
 const RowMap = (props: RowMapProps) => {
-
     const tiles = props.row.map((value, index) => (
         <Tile
-            key = {`${props.id}-${index}`}
-            asset = {props.mapAssets[value]}
-            Xid = {index}
-            Yid = {props.id}
-            fixTop = {props.constants.FIX_TOP}
-            fixLeft = {props.constants.FIX_LEFT}
-        />)
-    );
+            key={`${props.id}-${index}`}
+            asset={props.mapAssets[value]}
+            Xid={index}
+            Yid={props.id}
+            fixTop={props.constants.FIX_TOP}
+            fixLeft={props.constants.FIX_LEFT}
+        />
+    ));
 
-    return (
-        <div style = {{display: 'flex'}}>
-            {tiles}
-        </div >
-    );
+    return <div style={{ display: 'flex' }}>{tiles}</div>;
 };
 
 interface WorldMapProps {
     mapLevel: number[][];
     mapAssets: Record<number, TileAsset>;
-    constants: {FIX_TOP: number; FIX_LEFT: number};
+    constants: { FIX_TOP: number; FIX_LEFT: number };
 }
 
 const WorldMap = (props: WorldMapProps) => {
-
     const rows = props.mapLevel.map((row, index) => (
-        <RowMap key = {`row-${index}`}
-                id = {index}
-                mapAssets = {props.mapAssets}
-                row = {row}
-                constants = {props.constants}
-        />));
+        <RowMap
+            key={`row-${index}`}
+            id={index}
+            mapAssets={props.mapAssets}
+            row={row}
+            constants={props.constants}
+        />
+    ));
 
-    return (
-        <div className = {classes.worldMap}>
-            {rows}
-        </div >
-    );
+    return <div className={classes.worldMap}>{rows}</div>;
 };
 
 export default WorldMap;

--- a/src/components/Game/WorldMap/WorldMapContainer.tsx
+++ b/src/components/Game/WorldMap/WorldMapContainer.tsx
@@ -6,10 +6,10 @@ import { useGameStore } from '../../../stores/gameStore';
 // Статичные данные уровня (карта, тайлы) не дублируются в сторе:
 // единственный источник правды — LEVELS, стор хранит только номер уровня.
 const WorldMapContainer = () => {
-    const level = useGameStore(state => state.level);
-    const {levelMap, levelAssets} = LEVELS[level];
+    const level = useGameStore((state) => state.level);
+    const { levelMap, levelAssets } = LEVELS[level];
 
-    return <WorldMap mapLevel = {levelMap} mapAssets = {levelAssets} constants = {CONSTANTS} />;
+    return <WorldMap mapLevel={levelMap} mapAssets={levelAssets} constants={CONSTANTS} />;
 };
 
 export default WorldMapContainer;

--- a/src/components/MainMenu/Button/Button.tsx
+++ b/src/components/MainMenu/Button/Button.tsx
@@ -1,4 +1,4 @@
-import classes from './Button.module.sass'
+import classes from './Button.module.sass';
 
 interface ButtonProps {
     text: string;
@@ -6,19 +6,25 @@ interface ButtonProps {
 
 const Button = (props: ButtonProps) => {
     return (
-            <button className={classes.mainButton}>
-                <svg width="315" height="60" viewBox="0 0 302 62" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <defs>
-                        <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                            <stop offset="0%"   stopColor ="rgba(3,8,22,.92)"/>
-                            <stop offset="55%"  stopColor ="rgba(0,240,255,.12)"/>
-                            <stop offset="100%" stopColor ="rgba(5,2,26,.92)"/>
-                        </linearGradient>
-                    </defs>
-                    <path d="M118.13 1H7.29888L1 7.07594V48.4684L7.29888 55.6835H189.246L196.173 61H294.997L301 55.6835V12.7722L294.997 7.07594H125.98L118.13 1Z" />
-                </svg>
-                <p>{props.text}</p>
-            </button>
+        <button className={classes.mainButton}>
+            <svg
+                width="315"
+                height="60"
+                viewBox="0 0 302 62"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <defs>
+                    <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                        <stop offset="0%" stopColor="rgba(3,8,22,.92)" />
+                        <stop offset="55%" stopColor="rgba(0,240,255,.12)" />
+                        <stop offset="100%" stopColor="rgba(5,2,26,.92)" />
+                    </linearGradient>
+                </defs>
+                <path d="M118.13 1H7.29888L1 7.07594V48.4684L7.29888 55.6835H189.246L196.173 61H294.997L301 55.6835V12.7722L294.997 7.07594H125.98L118.13 1Z" />
+            </svg>
+            <p>{props.text}</p>
+        </button>
     );
 };
 

--- a/src/components/MainMenu/Menu.tsx
+++ b/src/components/MainMenu/Menu.tsx
@@ -9,18 +9,22 @@ interface MenuProps {
 
 const Menu = (props: MenuProps) => {
     const optionsList = props.menuOptions.map((o, index) => (
-        <NavLink key = {index} className = {({isActive}) => isActive ? classes.menuItem : undefined} to = {o.link}>
-            <Button text = {o.label} />
-        </NavLink >
+        <NavLink
+            key={index}
+            className={({ isActive }) => (isActive ? classes.menuItem : undefined)}
+            to={o.link}
+        >
+            <Button text={o.label} />
+        </NavLink>
     ));
 
     return (
-        <div className = {classes.menuBackground}>
-            <h1 className = {classes.title} data-text = "Crawler">Crawler</h1 >
-            <div className = {classes.menuContainer}>
-                {optionsList}
-            </div >
-        </div >
+        <div className={classes.menuBackground}>
+            <h1 className={classes.title} data-text="Crawler">
+                Crawler
+            </h1>
+            <div className={classes.menuContainer}>{optionsList}</div>
+        </div>
     );
 };
 

--- a/src/components/MainMenu/MenuContainer.tsx
+++ b/src/components/MainMenu/MenuContainer.tsx
@@ -2,9 +2,9 @@ import Menu from './Menu';
 import { useCommonAppStore } from '../../stores/commonAppStore';
 
 const MenuContainer = () => {
-    const menuOptions = useCommonAppStore(state => state.menuOptions);
+    const menuOptions = useCommonAppStore((state) => state.menuOptions);
 
-    return <Menu menuOptions = {menuOptions}/>;
+    return <Menu menuOptions={menuOptions} />;
 };
 
 export default MenuContainer;

--- a/src/components/PlayerInfo/PlayerInfo.tsx
+++ b/src/components/PlayerInfo/PlayerInfo.tsx
@@ -1,9 +1,5 @@
 const PlayerInfo = () => {
-    return (
-        <div >
-
-        </div >
-    );
+    return <div></div>;
 };
 
 export default PlayerInfo;

--- a/src/components/PlayerInfo/PlayerInfoContainer.tsx
+++ b/src/components/PlayerInfo/PlayerInfoContainer.tsx
@@ -3,9 +3,7 @@ import PlayerInfo from './PlayerInfo';
 
 class PlayerInfoContainer extends Component {
     render() {
-        return (
-            <PlayerInfo/>
-        );
+        return <PlayerInfo />;
     }
 }
 

--- a/src/components/Preloader/Preloader.tsx
+++ b/src/components/Preloader/Preloader.tsx
@@ -4,20 +4,22 @@ import { animated, useSpring } from '@react-spring/web';
 
 const Preloader = () => {
     const containerStyle = useSpring({
-        from: {opacity: 0},
-        to: {opacity: 1},
+        from: { opacity: 0 },
+        to: { opacity: 1 },
     });
     const imageStyle = useSpring({
-        from: {opacity: 0},
-        to: {opacity: 1},
+        from: { opacity: 0 },
+        to: { opacity: 1 },
         delay: 1000,
     });
 
     return (
-        <animated.div className = {classes.preloaderContainer} style = {containerStyle}>
-            <animated.img src = {preloaderSvg} style = {imageStyle} alt = "Game is loading" />
-            <animated.p className = {classes.loadingText} style = {imageStyle}>Loading</animated.p >
-        </animated.div >
+        <animated.div className={classes.preloaderContainer} style={containerStyle}>
+            <animated.img src={preloaderSvg} style={imageStyle} alt="Game is loading" />
+            <animated.p className={classes.loadingText} style={imageStyle}>
+                Loading
+            </animated.p>
+        </animated.div>
     );
 };
 

--- a/src/gameCore/constants.ts
+++ b/src/gameCore/constants.ts
@@ -1,13 +1,13 @@
 const CONSTANTS = {
-    SPRITE_SIZE : 50,
+    SPRITE_SIZE: 50,
     MAP_COLUMNS: 16,
     MAP_ROWS: 16,
     MAP_WIDTH: 800,
-    MAP_HEIGHT : 800,
+    MAP_HEIGHT: 800,
     FIX_TOP: 0,
     FIX_LEFT: 0,
     GAME_ANIMATE_SPEED: 300, // in milliseconds
-    PHASE_COUNT_ANIMATION: 2 // start from 0 phase
+    PHASE_COUNT_ANIMATION: 2, // start from 0 phase
 } as const;
 
 export const GAME_MODES = Object.freeze({
@@ -16,7 +16,7 @@ export const GAME_MODES = Object.freeze({
     BATTLE: 'battle',
 } as const);
 
-export type GameMode = typeof GAME_MODES[keyof typeof GAME_MODES];
+export type GameMode = (typeof GAME_MODES)[keyof typeof GAME_MODES];
 
 export const DIRECTIONS = Object.freeze({
     WEST: 'W',
@@ -25,7 +25,7 @@ export const DIRECTIONS = Object.freeze({
     SOUTH: 'S',
 } as const);
 
-export type Direction = typeof DIRECTIONS[keyof typeof DIRECTIONS];
+export type Direction = (typeof DIRECTIONS)[keyof typeof DIRECTIONS];
 
 export const KEY_TO_DIRECTION: Readonly<Record<string, Direction>> = Object.freeze({
     ArrowLeft: DIRECTIONS.WEST,
@@ -42,13 +42,13 @@ export const OBJECT_TYPES = Object.freeze({
     BATTLE: 'battle',
 } as const);
 
-export type GameObjectType = typeof OBJECT_TYPES[keyof typeof OBJECT_TYPES];
+export type GameObjectType = (typeof OBJECT_TYPES)[keyof typeof OBJECT_TYPES];
 
 export const SPEAKER_ROLES = Object.freeze({
     HERO: 'hero',
     ENEMY: 'enemy',
 } as const);
 
-export type SpeakerRole = typeof SPEAKER_ROLES[keyof typeof SPEAKER_ROLES];
+export type SpeakerRole = (typeof SPEAKER_ROLES)[keyof typeof SPEAKER_ROLES];
 
-export default CONSTANTS
+export default CONSTANTS;

--- a/src/gameCore/controller.ts
+++ b/src/gameCore/controller.ts
@@ -7,7 +7,7 @@ import type { Coords, GameAction, GameEventCheck, GameObject, Level, TileAsset }
  * не выходя за границы карты.
  */
 export const calculateNewCoords = (prevCoords: Coords, direction: Direction): Coords => {
-    const newCoords = {...prevCoords};
+    const newCoords = { ...prevCoords };
     switch (direction) {
         case DIRECTIONS.WEST:
             if (prevCoords.x > 0) {
@@ -42,9 +42,7 @@ const calculateWalkIndex = (gameObject: GameObject, direction: Direction): numbe
     if (direction !== gameObject.prevDirection) {
         return 1;
     }
-    return gameObject.walkIndex < CONSTANTS.PHASE_COUNT_ANIMATION
-        ? gameObject.walkIndex + 1
-        : 0;
+    return gameObject.walkIndex < CONSTANTS.PHASE_COUNT_ANIMATION ? gameObject.walkIndex + 1 : 0;
 };
 
 export interface GameTickResult {
@@ -65,7 +63,7 @@ export const getUpdatedGameObjects = (
 ): GameTickResult => {
     let heroChangedPosition = true;
 
-    const newGameObjects = gameObjects.map(obj => {
+    const newGameObjects = gameObjects.map((obj) => {
         switch (action.type) {
             case 'move': {
                 if (obj.type !== OBJECT_TYPES.HERO) {
@@ -75,8 +73,8 @@ export const getUpdatedGameObjects = (
 
                 const newCoords = calculateNewCoords(obj.coords, action.direction);
                 const canMove = isWalkable(newCoords, level.levelMap, level.levelAssets);
-                const positionChanged = canMove &&
-                    (newCoords.x !== obj.coords.x || newCoords.y !== obj.coords.y);
+                const positionChanged =
+                    canMove && (newCoords.x !== obj.coords.x || newCoords.y !== obj.coords.y);
 
                 if (!positionChanged) {
                     heroChangedPosition = false;
@@ -98,8 +96,8 @@ export const getUpdatedGameObjects = (
     return {
         newGameObjects,
         info: {
-            heroChangedPosition
-        }
+            heroChangedPosition,
+        },
     };
 };
 
@@ -107,18 +105,20 @@ export const getUpdatedGameObjects = (
  * Ищет событийный объект (диалог, битва) на клетке героя.
  */
 export const checkOnGameEvent = (gameObjects: GameObject[]): GameEventCheck => {
-    const hero = gameObjects.find(obj => obj.type === OBJECT_TYPES.HERO);
+    const hero = gameObjects.find((obj) => obj.type === OBJECT_TYPES.HERO);
     if (!hero) {
-        return {isGameEvent: false, eventObject: null};
+        return { isGameEvent: false, eventObject: null };
     }
     const heroPos = hero.coords;
-    const eventObject = gameObjects.find(obj =>
-        (obj.type === OBJECT_TYPES.DIALOG || obj.type === OBJECT_TYPES.BATTLE) &&
-        obj.coords.x === heroPos.x && obj.coords.y === heroPos.y
+    const eventObject = gameObjects.find(
+        (obj) =>
+            (obj.type === OBJECT_TYPES.DIALOG || obj.type === OBJECT_TYPES.BATTLE) &&
+            obj.coords.x === heroPos.x &&
+            obj.coords.y === heroPos.y,
     );
     return {
         isGameEvent: eventObject !== undefined,
-        eventObject: eventObject ?? null
+        eventObject: eventObject ?? null,
     };
 };
 

--- a/src/gameCore/levels/LEVELS.ts
+++ b/src/gameCore/levels/LEVELS.ts
@@ -56,64 +56,64 @@ export const LEVELS: Record<number, Level> = {
                 left: 80,
                 sizeX: CONSTANTS.SPRITE_SIZE,
                 sizeY: CONSTANTS.SPRITE_SIZE,
-            }
+            },
         },
         gameObjects: [
             {
                 id: 1,
                 type: OBJECT_TYPES.HERO,
-                coords: {x: 0, y: 0},
+                coords: { x: 0, y: 0 },
                 sprite: hero_sprite_sheet,
                 walkIndex: 0,
                 prevDirection: DIRECTIONS.SOUTH,
-                currentDirection: DIRECTIONS.SOUTH
+                currentDirection: DIRECTIONS.SOUTH,
             },
             {
                 id: 2,
                 type: OBJECT_TYPES.TREASURE_CHEST,
-                coords: {x: 5, y: 5},
+                coords: { x: 5, y: 5 },
                 sprite: '',
                 walkIndex: 0,
                 prevDirection: DIRECTIONS.SOUTH,
-                currentDirection: DIRECTIONS.SOUTH
+                currentDirection: DIRECTIONS.SOUTH,
             },
             {
                 id: 3,
                 type: OBJECT_TYPES.MONSTER,
-                coords: {x: 10, y: 10},
+                coords: { x: 10, y: 10 },
                 sprite: '',
                 walkIndex: 0,
                 prevDirection: DIRECTIONS.SOUTH,
-                currentDirection: DIRECTIONS.SOUTH
+                currentDirection: DIRECTIONS.SOUTH,
             },
             {
                 id: 4,
                 type: OBJECT_TYPES.DIALOG,
                 dialogId: 1,
-                coords: {x: 2, y: 1},
+                coords: { x: 2, y: 1 },
                 sprite: '',
                 walkIndex: 0,
                 prevDirection: DIRECTIONS.SOUTH,
-                currentDirection: DIRECTIONS.SOUTH
-            }
+                currentDirection: DIRECTIONS.SOUTH,
+            },
         ],
         dialogs: {
             speakersData: [
                 {
                     name: 'Leia',
                     role: SPEAKER_ROLES.HERO,
-                    sprite: hero_avatar
+                    sprite: hero_avatar,
                 },
                 {
                     name: 'Grimm',
                     role: SPEAKER_ROLES.ENEMY,
-                    sprite: enemy_avatar
+                    sprite: enemy_avatar,
                 },
                 {
                     name: 'Незнакомец',
                     role: SPEAKER_ROLES.ENEMY,
-                    sprite: enemy_avatar
-                }
+                    sprite: enemy_avatar,
+                },
             ],
             dialogList: {
                 1: {
@@ -122,54 +122,53 @@ export const LEVELS: Record<number, Level> = {
                     phrases: [
                         {
                             speaker: 'Leia',
-                            text: 'Черт, не стоило надеяться, что навигатор сможет работать в такую магнитную бурю...'
+                            text: 'Черт, не стоило надеяться, что навигатор сможет работать в такую магнитную бурю...',
                         },
                         {
                             speaker: 'Leia',
-                            text: 'Видимо, придется искать лачугу, в которой можно будет пересидеть до остановки реактора.'
+                            text: 'Видимо, придется искать лачугу, в которой можно будет пересидеть до остановки реактора.',
                         },
                         {
                             speaker: 'Незнакомец',
-                            text: 'С каких пор по нашему гнилому краю в одиночистве гуляют такие красотки?'
+                            text: 'С каких пор по нашему гнилому краю в одиночистве гуляют такие красотки?',
                         },
                         {
                             speaker: 'Leia',
-                            text: 'С тех самых, когда здесь начали случайным образом пропадать люди.'
+                            text: 'С тех самых, когда здесь начали случайным образом пропадать люди.',
                         },
                         {
                             speaker: 'Leia',
-                            text: 'Поэтому рекомендую держать дистанцию, если не хочешь, чтобы я отстрелила тебе чего-нибудь.'
+                            text: 'Поэтому рекомендую держать дистанцию, если не хочешь, чтобы я отстрелила тебе чего-нибудь.',
                         },
                         {
                             speaker: 'Незнакомец',
-                            text: 'Леди, быть столь грубой в Фризленде - сродни самоубийству... Но Гримм сегодня в хорошем настроении!'
+                            text: 'Леди, быть столь грубой в Фризленде - сродни самоубийству... Но Гримм сегодня в хорошем настроении!',
                         },
                         {
                             speaker: 'Grimm',
-                            text: 'Меня зовут Гримм, я работаю проводником в долине Фризленда'
+                            text: 'Меня зовут Гримм, я работаю проводником в долине Фризленда',
                         },
                         {
                             speaker: 'Grimm',
-                            text: 'Ты из нового отряда Ревёрсеров. На прошлой неделе один из ваших отказался от помощи, теперь его тело доедают догзайленты на входе'
+                            text: 'Ты из нового отряда Ревёрсеров. На прошлой неделе один из ваших отказался от помощи, теперь его тело доедают догзайленты на входе',
                         },
                         {
                             speaker: 'Leia',
-                            text: 'Я не хотела верить в смерть Йохана, но если это действительно так, дай мне убедиться в этом своими глазами'
+                            text: 'Я не хотела верить в смерть Йохана, но если это действительно так, дай мне убедиться в этом своими глазами',
                         },
                         {
                             speaker: 'Leia',
-                            text: 'После чего я буду готова обсудить твоё вознаграждение и дальнейшеее сотрудничество'
+                            text: 'После чего я буду готова обсудить твоё вознаграждение и дальнейшеее сотрудничество',
                         },
                         {
                             speaker: 'Grimm',
-                            text: 'Не отставай!'
+                            text: 'Не отставай!',
                         },
-                    ]
-                }
-            }
-        }
-    }
+                    ],
+                },
+            },
+        },
+    },
 };
-
 
 export default LEVELS;

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import "./assets/fonts/CyberfunkImport/Cyberfunk.css";
+@import './assets/fonts/CyberfunkImport/Cyberfunk.css';
 
 :root {
     /* Дизайн-токены киберпанк-палитры — единственный источник цветов UI */
@@ -12,9 +12,9 @@
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+    font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+        'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
     margin: 0;
     background-color: var(--cyber-bg);
     -webkit-font-smoothing: antialiased;
@@ -22,8 +22,7 @@ body {
 }
 
 code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 ::selection {
@@ -32,7 +31,7 @@ code {
 }
 
 a {
-  text-decoration: none !important;
+    text-decoration: none !important;
 }
 
 .App {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,4 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import AppContainer from './AppContainer';
 
-
-createRoot(document.getElementById('root')!).render(
-    <AppContainer />
-);
+createRoot(document.getElementById('root')!).render(<AppContainer />);

--- a/src/stores/commonAppStore.ts
+++ b/src/stores/commonAppStore.ts
@@ -22,17 +22,18 @@ export const useCommonAppStore = create<CommonAppStore>()(
             menuOptions: [
                 {
                     label: 'New game',
-                    link: '/game'
+                    link: '/game',
                 },
                 {
                     label: 'About developer',
-                    link: '/about'
-                }
+                    link: '/about',
+                },
             ],
 
-            switchPreloader: (status) => set({isLoading: status}, false, 'switchPreloader'),
-            changeBackgroundImage: (url) => set({backgroundImageUrl: url}, false, 'changeBackgroundImage'),
+            switchPreloader: (status) => set({ isLoading: status }, false, 'switchPreloader'),
+            changeBackgroundImage: (url) =>
+                set({ backgroundImageUrl: url }, false, 'changeBackgroundImage'),
         }),
-        {name: 'commonApp'},
+        { name: 'commonApp' },
     ),
 );

--- a/src/stores/dialogsStore.ts
+++ b/src/stores/dialogsStore.ts
@@ -24,22 +24,27 @@ export const useDialogsStore = create<DialogsStore>()(
             speakersData: [],
             dialogList: {},
 
-            loadDialogs: (dialogsData) => set(
-                {speakersData: dialogsData.speakersData, dialogList: dialogsData.dialogList},
-                false, 'loadDialogs'),
-            setCurrentDialog: (dialogId) => set(
-                {currentDialogId: dialogId, typing: true},
-                false, 'setCurrentDialog'),
-            addReadDialog: (dialogId) => set(
-                (state) => ({
-                    alreadyReadIndexes: state.dialogList[dialogId].isDisposable
-                        ? [...state.alreadyReadIndexes, dialogId]
-                        : state.alreadyReadIndexes,
-                    currentDialogId: 0,
-                }),
-                false, 'addReadDialog'),
-            setTyping: (typingState) => set({typing: typingState}, false, 'setTyping'),
+            loadDialogs: (dialogsData) =>
+                set(
+                    { speakersData: dialogsData.speakersData, dialogList: dialogsData.dialogList },
+                    false,
+                    'loadDialogs',
+                ),
+            setCurrentDialog: (dialogId) =>
+                set({ currentDialogId: dialogId, typing: true }, false, 'setCurrentDialog'),
+            addReadDialog: (dialogId) =>
+                set(
+                    (state) => ({
+                        alreadyReadIndexes: state.dialogList[dialogId].isDisposable
+                            ? [...state.alreadyReadIndexes, dialogId]
+                            : state.alreadyReadIndexes,
+                        currentDialogId: 0,
+                    }),
+                    false,
+                    'addReadDialog',
+                ),
+            setTyping: (typingState) => set({ typing: typingState }, false, 'setTyping'),
         }),
-        {name: 'dialogs'},
+        { name: 'dialogs' },
     ),
 );

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -21,12 +21,11 @@ export const useGameStore = create<GameStore>()(
             // сущности приходят из данных уровня (LEVELS[n].gameObjects) при loadLevel
             gameObjects: [],
 
-            loadLevel: (level) => set(
-                {level: level.level, gameObjects: level.gameObjects},
-                false, 'loadLevel'),
-            setGameMode: (gameMode) => set({gameMode}, false, 'setGameMode'),
-            setGameObjects: (gameObjects) => set({gameObjects}, false, 'setGameObjects'),
+            loadLevel: (level) =>
+                set({ level: level.level, gameObjects: level.gameObjects }, false, 'loadLevel'),
+            setGameMode: (gameMode) => set({ gameMode }, false, 'setGameMode'),
+            setGameObjects: (gameObjects) => set({ gameObjects }, false, 'setGameObjects'),
         }),
-        {name: 'game'},
+        { name: 'game' },
     ),
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,25 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
+    "compilerOptions": {
+        "target": "ES2022",
+        "useDefineForClassFields": true,
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
 
-    /* Bundler mode (Vite) */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
+        /* Bundler mode (Vite) */
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "verbatimModuleSyntax": true,
+        "moduleDetection": "force",
+        "noEmit": true,
+        "jsx": "react-jsx",
 
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  },
-  "include": ["src", "vite.config.ts"]
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedSideEffectImports": true
+    },
+    "include": ["src", "vite.config.ts"]
 }


### PR DESCRIPTION
## Что сделано

Первая итерация цикла «привести репозиторий к лучшим практикам»: статический анализ и единый код-стайл, зафиксированные в CI.

### ESLint (`eslint.config.js`, flat config)
- `@eslint/js` recommended + `typescript-eslint` recommended
- `react-hooks` (rules-of-hooks — error, exhaustive-deps — warn) и `react-refresh` для Vite
- `eslint-config-prettier`, чтобы правила не конфликтовали с форматтером
- Неиспользуемые аргументы/переменные допустимы только с префиксом `_`
- Скрипт `npm run lint` = `eslint . --max-warnings 0`

### Prettier
- Конфиг под стиль проекта: 4 пробела, одинарные кавычки, trailing commas, printWidth 100
- `.sass`-файлы исключены (Prettier не поддерживает indented-синтаксис), как и `package-lock.json`
- Прогнан по всей кодовой базе — единообразное форматирование всех `.ts/.tsx/.css/.json/.md/.yml`
- Скрипты `npm run format` и `npm run format:check`

### Исправления по находкам линтера
- `DialogBox.tsx`: добавлена недостающая зависимость `props.text` в `useMemo`

### CI
- В джобу добавлены шаги **Lint** и **Check formatting** перед typecheck + build; джоба переименована в «Lint, Typecheck & Build»

### Документация
- CLAUDE.md: новые команды и описание правил код-стайла

## Проверки
- `npm run lint`, `npm run format:check`, `npm run typecheck`, `vite build` — всё зелёное локально
- Playwright-смоук после переформатирования: полный цикл диалога, одноразовость триггера, меню/прелоадер/About — без ошибок в консоли

## Дальше в цикле
Следующие итерации (отдельными PR после мержа этого): тесты игрового ядра (Vitest), автоматизация релизов, Dependabot и шаблоны PR/issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi)_