### PR TITLE
Update and harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,25 @@ on:
         branches: [master]
     pull_request:
 
+permissions:
+    contents: read
+
+# не гоняем устаревшие прогоны: новый пуш в ту же ветку отменяет предыдущий
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     check:
         name: Lint, Test & Build
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: .nvmrc
                   cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,13 @@ jobs:
     release:
         name: Build & Publish Release
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: .nvmrc
                   cache: npm
@@ -39,7 +40,7 @@ jobs:
                   zip -r ../crawler-game-${{ github.ref_name }}.zip .
 
             - name: Create GitHub Release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3
               with:
                   generate_release_notes: true
                   files: crawler-game-${{ github.ref_name }}.zip


### PR DESCRIPTION
## Что сделано

Пятая итерация цикла «лучшие практики»: актуальные версии actions и «закалка» воркфлоу.

- **Обновлены версии actions** до предложенных Dependabot: `actions/checkout@v7`, `actions/setup-node@v6`, `softprops/action-gh-release@v3`. Этот PR заменяет Dependabot-PR #41, #42, #43 — после его мержа Dependabot закроет их сам как неактуальные.
- **CI hardening**:
  - `permissions: contents: read` — минимальные права токена (least privilege)
  - `concurrency` с `cancel-in-progress` — новый пуш в ветку отменяет устаревший прогон вместо траты минут Actions
  - `timeout-minutes: 10` — зависший прогон не висит 6 часов по умолчанию
- **Release workflow**: `timeout-minutes: 15`

## Как проверить

- YAML-синтаксис провалидирован (yaml-lint), форматирование — Prettier
- Зелёный прогон CI на этом самом PR подтвердит checkout@v7 и setup-node@v6; gh-release@v3 сработает при первом пуше тега `v*`

## Чеклист

- [x] `npm run lint` и `npm run format:check` проходят
- [x] `npm run typecheck` без ошибок
- [x] `npm test` зелёный
- [x] Игра проверена в браузере — не требуется (код приложения не менялся)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi)_