### PR TITLE
Add MIT license, GitHub Pages deploy, and bump version to 0.2.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+    push:
+        branches: [master]
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# один деплой за раз; начатый прогон не отменяем
+concurrency:
+    group: pages
+    cancel-in-progress: false
+
+jobs:
+    deploy:
+        name: Build & Deploy
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: .nvmrc
+                  cache: npm
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build
+              run: npx vite build
+
+            - name: Setup Pages
+              uses: actions/configure-pages@v5
+              with:
+                  enablement: true
+
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v4
+              with:
+                  path: dist
+
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,9 @@ Tests are Vitest, co-located with the code (`src/**/*.test.ts`) — pure gameCor
 
 Releases are tag-driven: pushing a `v*` tag (e.g. `npm version minor && git push --follow-tags`) triggers `.github/workflows/release.yml`, which re-runs checks, builds, and publishes a GitHub Release with auto-generated notes and a zipped `dist/`. Dependabot opens weekly PRs for npm (minor+patch grouped into one PR) and GitHub Actions updates.
 
-A husky pre-commit hook runs lint-staged (ESLint + Prettier on staged files); `npm install` wires it up via the `prepare` script. Code style is enforced by Prettier (4-space indent, single quotes, trailing commas); ESLint layers typescript-eslint recommended plus react-hooks and react-refresh rules (unused args/vars are allowed only with a `_` prefix).
+A husky pre-commit hook runs lint-staged (ESLint + Prettier on staged files); `npm install` wires it up via the `prepare` script.
+
+Every push to master also deploys the game to GitHub Pages (`.github/workflows/deploy.yml`). The Vite build uses `base: './'` (relative asset paths) and the router is hash-based, so the bundle works under any URL prefix without rebuilding. Code style is enforced by Prettier (4-space indent, single quotes, trailing commas); ESLint layers typescript-eslint recommended plus react-hooks and react-refresh rules (unused args/vars are allowed only with a `_` prefix).
 
 ## Overview
 
@@ -30,7 +32,7 @@ TypeScript conventions: domain types (`GameObject`, `Level`, `TileAsset`, dialog
 
 ## Architecture
 
-Entry flow: `index.html` → `src/main.tsx` (creates the root; Zustand needs no provider) → `AppContainer` (shows a fake 2s preloader) → `App.tsx` (`BrowserRouter` with routes `/` menu, `/game`, `/character`, `/about`).
+Entry flow: `index.html` → `src/main.tsx` (creates the root; Zustand needs no provider) → `AppContainer` (shows a fake 2s preloader) → `App.tsx` (`HashRouter` with routes `/` menu, `/game`, `/character`, `/about` — hash-based so the SPA works on GitHub Pages; in the browser they look like `/#/game`).
 
 The codebase splits into three layers:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vadim Korolev (VadimOnix)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A small browser crawler game written in TypeScript, built with React 19 and [Vite](https://vite.dev/).
 
+**Play online:** https://vadimonix.github.io/crawler-game/ (deployed automatically from `master` via GitHub Pages; the URL follows the repository name).
+
 ## Requirements
 
 - Node.js 20.19+ (an active LTS release — 22 or 24 — is recommended, see `.nvmrc`)
@@ -57,6 +59,10 @@ Serves the production build from `dist` locally for a final check before deployi
 - **CI** (`.github/workflows/ci.yml`): lint, format check, typecheck, tests, and build run on every push to `master` and on pull requests.
 - **Dependabot**: weekly dependency updates (minor and patch npm updates grouped into a single PR).
 
+## Deployment
+
+Every push to `master` triggers `.github/workflows/deploy.yml`, which builds the game and publishes it to GitHub Pages. The build uses a relative base path (`base: './'` in `vite.config.ts`) and a `HashRouter`, so it works under any URL prefix — renaming the repository or attaching a custom domain requires no code changes.
+
 ## Releases
 
 Releases are tag-driven. Bump the version and push the tag:
@@ -67,3 +73,7 @@ git push --follow-tags
 ```
 
 The `Release` workflow re-runs all checks, builds the game, and publishes a GitHub Release with auto-generated notes and a zipped `dist/`.
+
+## License
+
+[MIT](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "crawler-game",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "private": true,
     "type": "module",
     "engines": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { HashRouter, Route, Routes } from 'react-router-dom';
 import MenuContainer from './components/MainMenu/MenuContainer';
 import GameContainer from './components/Game/GameContainer';
 import PlayerInfoContainer from './components/PlayerInfo/PlayerInfoContainer';
@@ -27,11 +27,13 @@ const App = (props: AppProps) => {
     );
 
     return (
-        <BrowserRouter>
+        // HashRouter вместо BrowserRouter: статический хостинг (GitHub Pages)
+        // не умеет отдавать index.html по произвольным путям SPA
+        <HashRouter>
             <div className="App" style={appStyle}>
                 <div className="AppWrapper">{content}</div>
             </div>
-        </BrowserRouter>
+        </HashRouter>
     );
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+    // относительные пути к ассетам: сборка работает под любым базовым URL
+    // (vadimonix.github.io/<repo>, кастомный домен и т.п.)
+    base: './',
     plugins: [react()],
     server: {
         port: 3000,


### PR DESCRIPTION
## Что сделано

Три пункта из финального списка: лицензия, деплой, подготовка первого релиза.

- **LICENSE** — MIT (Copyright Vadim Korolev / VadimOnix). Если хочешь другую — замени файл, это единственное место.
- **Деплой на GitHub Pages** (`.github/workflows/deploy.yml`) — каждый пуш в `master` собирает игру и публикует её на Pages (официальная связка `configure-pages` → `upload-pages-artifact` → `deploy-pages`).
  - `vite.config.ts`: `base: './'` — относительные пути к ассетам, сборка работает под любым URL-префиксом
  - `App.tsx`: `HashRouter` вместо `BrowserRouter` — статический хостинг не умеет отдавать `index.html` по произвольным SPA-путям; роуты в браузере выглядят как `/#/game`
  - Благодаря этому ссылка «переезжает» бесплатно: переименуешь репозиторий в `cyber-crawler` — игра станет доступна на `vadimonix.github.io/cyber-crawler` без единого изменения в коде
- **Версия 0.2.0** в `package.json` — после мержа запушу тег `v0.2.0`, и Release-workflow опубликует первый GitHub Release.
- **README**: ссылка «Play online», разделы Deployment и License.

## Как проверить

- Локальная симуляция Pages: сборка выложена под `http://localhost:8090/cyber-crawler/`, Playwright-прогон из-под подпути: меню рендерится, переход `#/game` работает, доска (257 спрайтов), диалог с Leia открывается, прямой заход на `#/about` работает, ни одной ошибки/упавшего запроса
- После мержа: экшен «Deploy to GitHub Pages» задеплоит сам; если Pages ещё не включён и шаг Setup Pages упадёт — включи один раз в Settings → Pages → Source: **GitHub Actions** и перезапусти workflow

## Чеклист

- [x] `npm run lint` и `npm run format:check` проходят
- [x] `npm run typecheck` без ошибок
- [x] `npm test` зелёный
- [x] Игра проверена в браузере (сборка из-под URL-подпути, полный смоук)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi)_