### PR TITLE
Allow triggering a release manually from the Actions tab

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
     push:
         tags: ['v*']
+    # ручной запуск из вкладки Actions: сам создаёт тег и публикует релиз
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Версия релиза без префикса v (например, 0.2.0)'
+                required: true
 
 permissions:
     contents: write
@@ -12,9 +18,17 @@ jobs:
         name: Build & Publish Release
         runs-on: ubuntu-latest
         timeout-minutes: 15
+        env:
+            RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref_name }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7
+
+            - name: Create tag (manual run)
+              if: github.event_name == 'workflow_dispatch'
+              run: |
+                  git tag "$RELEASE_TAG"
+                  git push origin "$RELEASE_TAG"
 
             - name: Setup Node.js
               uses: actions/setup-node@v6
@@ -37,10 +51,11 @@ jobs:
             - name: Archive build
               run: |
                   cd dist
-                  zip -r ../crawler-game-${{ github.ref_name }}.zip .
+                  zip -r "../crawler-game-$RELEASE_TAG.zip" .
 
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v3
               with:
+                  tag_name: ${{ env.RELEASE_TAG }}
                   generate_release_notes: true
-                  files: crawler-game-${{ github.ref_name }}.zip
+                  files: crawler-game-${{ env.RELEASE_TAG }}.zip


### PR DESCRIPTION
## Что сделано

Release-workflow теперь можно запускать вручную (`workflow_dispatch`) из вкладки Actions с указанием версии:

- Ручной запуск сам создаёт тег `v<version>` (пуш тега токеном воркфлоу не запускает дублирующий прогон — GitHub не триггерит события от GITHUB_TOKEN) и публикует GitHub Release с архивом игры
- Классический путь — пуш тега `v*` руками — работает как раньше: `RELEASE_TAG` берётся из `github.ref_name`

Зачем: возможность выпустить релиз в один клик из UI, без локального git. Сразу после мержа запущу его с версией `0.2.0` — это будет первый релиз.

## Как проверить

- YAML провалидирован (yaml-lint + Prettier)
- Реальная проверка — первый ручной запуск после мержа: должен появиться тег `v0.2.0` и Release с `crawler-game-v0.2.0.zip`

## Чеклист

- [x] `npm run lint` и `npm run format:check` проходят
- [x] `npm run typecheck` без ошибок
- [x] `npm test` зелёный
- [x] Игра проверена в браузере — не требуется (код приложения не менялся)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3eSGkSkAA1fKvoTacVSmi)_