### PR TITLE
Reset the run when entering the game and add a way back to the menu

### DIFF
--- a/src/components/Game/ExitToMenu/ExitToMenu.module.sass
+++ b/src/components/Game/ExitToMenu/ExitToMenu.module.sass
@@ -1,0 +1,43 @@
+// Кнопка выхода в меню: fixed, потому что на маленьких экранах поле
+// скроллится под ней (см. камеру в GameContainer)
+.exitButton
+  position: fixed
+  top: max(12px, env(safe-area-inset-top))
+  left: max(12px, env(safe-area-inset-left))
+  z-index: 900
+  display: flex
+  align-items: baseline
+  gap: 8px
+  padding: 8px 14px
+  font-family: var(--font-display)
+  font-size: .95rem
+  letter-spacing: .08em
+  text-transform: uppercase
+  color: #7df9ff
+  background: rgba(5, 10, 25, .6)
+  border: 1px solid rgba(0, 240, 255, .5)
+  border-radius: 10px
+  box-shadow: 0 0 12px rgba(0, 240, 255, .15)
+  backdrop-filter: blur(4px)
+  cursor: pointer
+  transition: color .2s ease, border-color .2s ease, box-shadow .2s ease
+  -webkit-tap-highlight-color: transparent
+
+  &:hover,
+  &:focus-visible
+    color: #ffffff
+    border-color: var(--cyber-magenta)
+    box-shadow: 0 0 16px rgba(255, 45, 149, .35)
+
+  &:active
+    transform: scale(.96)
+
+// подсказка про Esc бессмысленна там, где нет клавиатуры
+.hint
+  font-family: var(--font-mono)
+  font-size: .7rem
+  text-transform: none
+  color: var(--cyber-text-dim)
+
+  @media (pointer: coarse)
+    display: none

--- a/src/components/Game/ExitToMenu/ExitToMenu.tsx
+++ b/src/components/Game/ExitToMenu/ExitToMenu.tsx
@@ -1,0 +1,20 @@
+import classes from './ExitToMenu.module.sass';
+
+interface ExitToMenuProps {
+    onExit: () => void;
+}
+
+/**
+ * Выход с игрового экрана в главное меню. Без неё игровой экран —
+ * тупик: вернуться можно только кнопкой «назад» браузера.
+ */
+const ExitToMenu = (props: ExitToMenuProps) => {
+    return (
+        <button type="button" className={classes.exitButton} onClick={props.onExit}>
+            В меню
+            <span className={classes.hint}>Esc</span>
+        </button>
+    );
+};
+
+export default ExitToMenu;

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Game from './Game';
 import TouchControls from './TouchControls/TouchControls';
+import ExitToMenu from './ExitToMenu/ExitToMenu';
 import classes from './Game.module.sass';
 import CONSTANTS, { DIRECTIONS, KEY_TO_DIRECTION, OBJECT_TYPES } from '../../gameCore/constants';
 import LEVELS from '../../gameCore/levels/LEVELS';
@@ -12,6 +14,7 @@ import { movePlayer } from './movePlayer';
 const SWIPE_MIN_DISTANCE = 24;
 
 const GameContainer = () => {
+    const navigate = useNavigate();
     const gameMode = useGameStore((state) => state.gameMode);
     const heroX = useGameStore(
         (state) => state.gameObjects.find((obj) => obj.type === OBJECT_TYPES.HERO)?.coords.x,
@@ -31,10 +34,19 @@ const GameContainer = () => {
         useDialogsStore.getState().loadDialogs(levelData.dialogs);
     }, []);
 
+    // выход в меню; состояние партии сбрасывается при следующем входе
+    // на игровой экран (loadLevel + loadDialogs)
+    const exitToMenu = useCallback(() => navigate('/'), [navigate]);
+
     // клавиатура: обработчик стабилен, актуальное состояние читается
     // из сторов императивно — без протухших замыканий и переподписок
     useEffect(() => {
         const handleKeydown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                exitToMenu();
+                return;
+            }
             const direction = KEY_TO_DIRECTION[e.key];
             if (!direction) {
                 return;
@@ -45,7 +57,7 @@ const GameContainer = () => {
 
         window.addEventListener('keydown', handleKeydown);
         return () => window.removeEventListener('keydown', handleKeydown);
-    }, []);
+    }, [exitToMenu]);
 
     // сенсорные экраны: свайп по полю двигает героя
     useEffect(() => {
@@ -106,6 +118,7 @@ const GameContainer = () => {
     return (
         <div className={classes.viewport} ref={viewportRef}>
             <Game gameMode={gameMode} />
+            <ExitToMenu onExit={exitToMenu} />
             <TouchControls />
         </div>
     );

--- a/src/stores/dialogsStore.test.ts
+++ b/src/stores/dialogsStore.test.ts
@@ -25,6 +25,19 @@ describe('dialogsStore', () => {
         expect(state.dialogList).toEqual(DIALOGS.dialogList);
     });
 
+    it('loadDialogs сбрасывает прогресс прочтения предыдущей партии', () => {
+        useDialogsStore.getState().setCurrentDialog(1);
+        useDialogsStore.getState().addReadDialog(1);
+        useDialogsStore.getState().setTyping(false);
+
+        useDialogsStore.getState().loadDialogs(DIALOGS);
+
+        const state = useDialogsStore.getState();
+        expect(state.alreadyReadIndexes).toEqual([]);
+        expect(state.currentDialogId).toBe(0);
+        expect(state.typing).toBe(true);
+    });
+
     it('setCurrentDialog открывает диалог и включает печать текста', () => {
         useDialogsStore.getState().setTyping(false);
         useDialogsStore.getState().setCurrentDialog(1);

--- a/src/stores/dialogsStore.ts
+++ b/src/stores/dialogsStore.ts
@@ -8,6 +8,7 @@ interface DialogsStore {
     typing: boolean;
     speakersData: Speaker[];
     dialogList: Record<number, Dialog>;
+    /** загружает диалоги уровня и сбрасывает прогресс их прочтения */
     loadDialogs: (dialogsData: LevelDialogs) => void;
     setCurrentDialog: (dialogId: number) => void;
     /** закрывает диалог; одноразовые диалоги помечаются прочитанными */
@@ -24,9 +25,18 @@ export const useDialogsStore = create<DialogsStore>()(
             speakersData: [],
             dialogList: {},
 
+            // прогресс прочтения привязан к id диалогов уровня, поэтому
+            // сбрасывается вместе с ними — иначе «New game» пропустила бы
+            // вступительный диалог, уже прочитанный в прошлой партии
             loadDialogs: (dialogsData) =>
                 set(
-                    { speakersData: dialogsData.speakersData, dialogList: dialogsData.dialogList },
+                    {
+                        speakersData: dialogsData.speakersData,
+                        dialogList: dialogsData.dialogList,
+                        alreadyReadIndexes: [],
+                        currentDialogId: 0,
+                        typing: true,
+                    },
                     false,
                     'loadDialogs',
                 ),

--- a/src/stores/gameStore.test.ts
+++ b/src/stores/gameStore.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GAME_MODES } from '../gameCore/constants';
+import LEVELS from '../gameCore/levels/LEVELS';
+import { useGameStore } from './gameStore';
+
+const initialState = useGameStore.getState();
+
+describe('gameStore', () => {
+    beforeEach(() => {
+        useGameStore.setState(initialState, true);
+    });
+
+    it('loadLevel кладёт номер уровня и его объекты в стор', () => {
+        useGameStore.getState().loadLevel(LEVELS[1]);
+
+        const state = useGameStore.getState();
+        expect(state.level).toBe(1);
+        expect(state.gameObjects).toEqual(LEVELS[1].gameObjects);
+    });
+
+    it('loadLevel возвращает режим исследования', () => {
+        useGameStore.getState().setGameMode(GAME_MODES.SPEAKING);
+
+        useGameStore.getState().loadLevel(LEVELS[1]);
+
+        expect(useGameStore.getState().gameMode).toBe(GAME_MODES.EXPLORING);
+    });
+
+    it('loadLevel не мутирует объекты уровня', () => {
+        useGameStore.getState().loadLevel(LEVELS[1]);
+        const [firstObject] = useGameStore.getState().gameObjects;
+
+        useGameStore.getState().setGameObjects([{ ...firstObject, coords: { x: 9, y: 9 } }]);
+        useGameStore.getState().loadLevel(LEVELS[1]);
+
+        expect(useGameStore.getState().gameObjects).toEqual(LEVELS[1].gameObjects);
+    });
+});

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -8,6 +8,7 @@ interface GameStore {
     level: number;
     gameMode: GameMode;
     gameObjects: GameObject[];
+    /** загружает уровень с нуля: объекты из данных уровня, режим исследования */
     loadLevel: (level: Level) => void;
     setGameMode: (gameMode: GameMode) => void;
     setGameObjects: (gameObjects: GameObject[]) => void;
@@ -21,8 +22,18 @@ export const useGameStore = create<GameStore>()(
             // сущности приходят из данных уровня (LEVELS[n].gameObjects) при loadLevel
             gameObjects: [],
 
+            // gameMode сбрасывается вместе с объектами: иначе выход в меню
+            // посреди диалога вернул бы игрока в игру с открытым оверлеем
             loadLevel: (level) =>
-                set({ level: level.level, gameObjects: level.gameObjects }, false, 'loadLevel'),
+                set(
+                    {
+                        level: level.level,
+                        gameObjects: level.gameObjects,
+                        gameMode: GAME_MODES.EXPLORING,
+                    },
+                    false,
+                    'loadLevel',
+                ),
             setGameMode: (gameMode) => set({ gameMode }, false, 'setGameMode'),
             setGameObjects: (gameObjects) => set({ gameObjects }, false, 'setGameObjects'),
         }),


### PR DESCRIPTION
## Что сделано

Игровой экран был дверью в одну сторону с залипающим состоянием.

**Состояние не сбрасывалось.** `loadLevel` восстанавливал объекты уровня, но не трогал `gameMode`, а `loadDialogs` подменял данные диалогов, сохраняя `alreadyReadIndexes`. Последствия:

- выход из игры посреди диалога → возврат в `SPEAKING` с висящим оверлеем;
- второй «New game» молча пропускал вступительный диалог, прочитанный в прошлой партии.

Оба сброса теперь происходят при загрузке уровня: прогресс прочтения привязан к id диалогов конкретного уровня, то есть логически принадлежит этим данным.

**Не было выхода в меню.** Ни кнопки, ни клавиши — только жест «назад» в браузере, что практически неоткрываемо на мобильном, где видимый интерфейс — это D-pad. Добавил кнопку «В меню» (`position: fixed`, чтобы она не уезжала вместе с полем под мобильной камерой) и привязал к тому же действию Escape.

## Как проверить

```sh
npm start
```

1. New game → пройти к клетке (2,1) (вниз, вправо, вправо) → диалог открывается.
2. Пролистать диалог до конца → «В меню» → New game → **диалог играется снова**.
3. Дойти до диалога → `Esc` → возврат в меню → New game → **диалог закрыт, герой на старте**, оверлея нет.

Проверил этот сценарий в браузере целиком, ошибок в консоли нет. Плюс тесты: `loadDialogs сбрасывает прогресс прочтения предыдущей партии` и новый `gameStore.test.ts` (в том числе на то, что `loadLevel` не мутирует данные уровня).

## Чеклист

- [x] `npm run lint` и `npm run format:check` проходят
- [x] `npm run typecheck` без ошибок
- [x] `npm test` зелёный (35 тестов, было 31)
- [x] Игра проверена в браузере, если менялись UI или игровая логика


---
_Generated by [Claude Code](https://claude.ai/code/session_01NdNTQdr3VG6yobzQrEegW9)_