### PR TITLE
Fix event retriggering, input lock on blocked moves, and dialog input

### DIFF
--- a/src/components/Game/Dialog/Dialog.tsx
+++ b/src/components/Game/Dialog/Dialog.tsx
@@ -7,71 +7,61 @@ import { useGameStore } from '../../../stores/gameStore';
 import { useDialogsStore } from '../../../stores/dialogsStore';
 import DialogBox from './DialogBox';
 
-interface AnimatedBoxProps {
-    style: React.CSSProperties;
-}
-
 const Dialog = () => {
     const currentDialogId = useDialogsStore((state) => state.currentDialogId);
     const currDialogData = useDialogsStore((state) => state.dialogList[state.currentDialogId]);
     const speakersData = useDialogsStore((state) => state.speakersData);
     const typing = useDialogsStore((state) => state.typing);
 
-    const phrasesCount = currDialogData?.phrases.length ?? 0;
+    const [index, setIndex] = useState(0);
 
-    const getBoxes = useMemo(() => {
+    // фразы вместе с оформлением говорящего: роль задаёт вид рамки,
+    // спрайт — аватар в боксе
+    const phrases = useMemo(() => {
         if (!currDialogData) {
             return [];
         }
-        return currDialogData.phrases.map((p) => {
-            const speakerData = speakersData.find((char) => char.name === p.speaker);
-            const boxRole = speakerData?.role === SPEAKER_ROLES.HERO ? classes.hero : classes.enemy;
-            const spriteSrc = speakerData?.sprite ?? '';
-            return ({ style }: AnimatedBoxProps) => (
-                <animated.div style={{ ...style, position: 'absolute' }}>
-                    <DialogBox
-                        boxRole={boxRole}
-                        spriteSrc={spriteSrc}
-                        text={p.text}
-                        speaker={p.speaker}
-                    />
-                </animated.div>
-            );
+        return currDialogData.phrases.map((phrase) => {
+            const speakerData = speakersData.find((char) => char.name === phrase.speaker);
+            return {
+                speaker: phrase.speaker,
+                text: phrase.text,
+                boxRole: speakerData?.role === SPEAKER_ROLES.HERO ? classes.hero : classes.enemy,
+                spriteSrc: speakerData?.sprite ?? '',
+            };
         });
     }, [currDialogData, speakersData]);
 
-    const [index, setIndex] = useState(0);
+    const finishTyping = useCallback(() => useDialogsStore.getState().setTyping(false), []);
 
-    // следующая фраза или закрытие диалога; вызывается и по Enter, и по тапу
+    /**
+     * Единственный обработчик продвижения диалога — и для Enter, и для тапа.
+     * Пока фраза печатается, ввод её допечатывает; дальше листает фразы
+     * и закрывает диалог на последней.
+     */
     const advanceDialog = useCallback(() => {
         if (typing) {
+            finishTyping();
             return;
         }
-        if (index < phrasesCount - 1) {
+        if (index < phrases.length - 1) {
             useDialogsStore.getState().setTyping(true);
             setIndex(index + 1);
-        } else {
-            useGameStore.getState().setGameMode(GAME_MODES.EXPLORING);
-            useDialogsStore.getState().addReadDialog(currentDialogId);
+            return;
         }
-    }, [currentDialogId, typing, index, phrasesCount]);
+        useGameStore.getState().setGameMode(GAME_MODES.EXPLORING);
+        useDialogsStore.getState().addReadDialog(currentDialogId);
+    }, [currentDialogId, finishTyping, typing, index, phrases.length]);
 
-    const handleEnterKeydown = useCallback(
-        (e: KeyboardEvent) => {
+    useEffect(() => {
+        const handleKeydown = (e: KeyboardEvent) => {
             if (e.key === 'Enter') {
                 advanceDialog();
             }
-        },
-        [advanceDialog],
-    );
-
-    useEffect(() => {
-        window.addEventListener('keydown', handleEnterKeydown);
-
-        return () => {
-            window.removeEventListener('keydown', handleEnterKeydown);
         };
-    }, [handleEnterKeydown]);
+        window.addEventListener('keydown', handleKeydown);
+        return () => window.removeEventListener('keydown', handleKeydown);
+    }, [advanceDialog]);
 
     const transitions = useTransition(index, {
         from: { opacity: 0, transform: 'translateY(100%)' },
@@ -82,8 +72,25 @@ const Dialog = () => {
     return (
         <div className={classes.dialogBoxWrapper} onClick={advanceDialog}>
             {transitions((style, item) => {
-                const D = getBoxes[item];
-                return D ? <D style={style as unknown as React.CSSProperties} /> : null;
+                const phrase = phrases[item];
+                if (!phrase) {
+                    return null;
+                }
+                return (
+                    <animated.div style={{ ...style, position: 'absolute' }}>
+                        <DialogBox
+                            boxRole={phrase.boxRole}
+                            spriteSrc={phrase.spriteSrc}
+                            text={phrase.text}
+                            speaker={phrase.speaker}
+                            // уходящая фраза остаётся статичным текстом: иначе
+                            // она обнулила бы напечатанное прямо во время
+                            // анимации ухода
+                            typing={item === index && typing}
+                            onFinishedTyping={finishTyping}
+                        />
+                    </animated.div>
+                );
             })}
         </div>
     );

--- a/src/components/Game/Dialog/DialogBox.tsx
+++ b/src/components/Game/Dialog/DialogBox.tsx
@@ -1,61 +1,22 @@
-import { useMemo, useCallback, useEffect } from 'react';
 import classes from './Dialog.module.sass';
 import TypingText from './TypingText';
 import { animated, useSpring } from '@react-spring/web';
-import { useDialogsStore } from '../../../stores/dialogsStore';
 
 interface DialogBoxProps {
     boxRole: string;
     spriteSrc: string;
     text: string;
     speaker: string;
+    /** печатать фразу посимвольно или показать её целиком */
+    typing: boolean;
+    onFinishedTyping: () => void;
 }
 
+/**
+ * Презентационный бокс одной фразы. Ввод (Enter / тап) обрабатывает
+ * родительский Dialog — здесь нет ни подписок на стор, ни слушателей.
+ */
 const DialogBox = (props: DialogBoxProps) => {
-    const typing = useDialogsStore((state) => state.typing);
-
-    // мгновенно допечатать фразу; вызывается и по Enter, и по тапу
-    const skipTyping = useCallback(() => {
-        if (typing) {
-            useDialogsStore.getState().setTyping(false);
-        }
-    }, [typing]);
-
-    const handleEnterKeydown = useCallback(
-        (e: KeyboardEvent) => {
-            if (e.key === 'Enter') {
-                skipTyping();
-            }
-        },
-        [skipTyping],
-    );
-
-    useEffect(() => {
-        window.addEventListener('keydown', handleEnterKeydown);
-        return () => {
-            window.removeEventListener('keydown', handleEnterKeydown);
-        };
-    }, [handleEnterKeydown]);
-
-    const getTypingContent = useMemo(() => {
-        return typing ? (
-            <TypingText
-                className={classes.text}
-                cursorClassName={classes.cursor}
-                speed={3}
-                startDelay={700}
-                text={props.text}
-                onFinishedTyping={() => {
-                    useDialogsStore.getState().setTyping(false);
-                }}
-            />
-        ) : (
-            <div className={classes.text}>
-                <p>{props.text}</p>
-            </div>
-        );
-    }, [typing, props.text]);
-
     const nextPopupStyle = useSpring({
         from: { opacity: 0 },
         to: { opacity: 1 },
@@ -63,10 +24,23 @@ const DialogBox = (props: DialogBoxProps) => {
     });
 
     return (
-        <div className={[classes.dialogBox, props.boxRole].join(' ')} onClick={skipTyping}>
+        <div className={[classes.dialogBox, props.boxRole].join(' ')}>
             <img className={classes.avatar} src={props.spriteSrc} alt="" />
             <h3 className={classes.title}>{props.speaker}</h3>
-            {getTypingContent}
+            {props.typing ? (
+                <TypingText
+                    className={classes.text}
+                    cursorClassName={classes.cursor}
+                    speed={3}
+                    startDelay={700}
+                    text={props.text}
+                    onFinishedTyping={props.onFinishedTyping}
+                />
+            ) : (
+                <div className={classes.text}>
+                    <p>{props.text}</p>
+                </div>
+            )}
             <animated.div
                 style={{ position: 'absolute', ...nextPopupStyle }}
                 className={classes.nextPopup}

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -30,6 +30,9 @@ const GameContainer = () => {
     useEffect(() => {
         const { level, loadLevel } = useGameStore.getState();
         const levelData = LEVELS[level];
+        if (!levelData) {
+            return;
+        }
         loadLevel(levelData);
         useDialogsStore.getState().loadDialogs(levelData.dialogs);
     }, []);

--- a/src/components/Game/WorldMap/WorldMapContainer.tsx
+++ b/src/components/Game/WorldMap/WorldMapContainer.tsx
@@ -7,9 +7,20 @@ import { useGameStore } from '../../../stores/gameStore';
 // единственный источник правды — LEVELS, стор хранит только номер уровня.
 const WorldMapContainer = () => {
     const level = useGameStore((state) => state.level);
-    const { levelMap, levelAssets } = LEVELS[level];
+    const levelData = LEVELS[level];
 
-    return <WorldMap mapLevel={levelMap} mapAssets={levelAssets} constants={CONSTANTS} />;
+    // уровня с таким номером нет: рисовать нечего, но и падать незачем
+    if (!levelData) {
+        return null;
+    }
+
+    return (
+        <WorldMap
+            mapLevel={levelData.levelMap}
+            mapAssets={levelData.levelAssets}
+            constants={CONSTANTS}
+        />
+    );
 };
 
 export default WorldMapContainer;

--- a/src/components/Game/movePlayer.test.ts
+++ b/src/components/Game/movePlayer.test.ts
@@ -43,6 +43,32 @@ describe('movePlayer', () => {
         expect(useDialogsStore.getState().currentDialogId).toBe(1);
     });
 
+    it('не троттлит следующий ход, если герой упёрся в стену', () => {
+        // (0,0) — левый верхний угол: ход на запад невозможен, значит
+        // не должен глушить следующее нажатие
+        movePlayer(DIRECTIONS.WEST);
+        movePlayer(DIRECTIONS.SOUTH);
+        expect(getHero()?.coords).toEqual({ x: 0, y: 1 });
+    });
+
+    it('не открывает диалог заново, пока герой стоит на триггере', () => {
+        for (const direction of [DIRECTIONS.SOUTH, DIRECTIONS.EAST, DIRECTIONS.EAST]) {
+            resetMoveThrottle();
+            movePlayer(direction);
+        }
+        // диалог прочитан и закрыт, герой остался на клетке триггера
+        useDialogsStore.getState().addReadDialog(1);
+        useGameStore.getState().setGameMode(GAME_MODES.EXPLORING);
+        useDialogsStore.setState({ alreadyReadIndexes: [] });
+
+        // ход в стену: позиция не меняется, значит и события быть не должно
+        resetMoveThrottle();
+        movePlayer(DIRECTIONS.NORTH);
+
+        expect(getHero()?.coords).toEqual({ x: 2, y: 1 });
+        expect(useGameStore.getState().gameMode).toBe(GAME_MODES.EXPLORING);
+    });
+
     it('не двигает героя вне режима исследования', () => {
         useGameStore.getState().setGameMode(GAME_MODES.SPEAKING);
         movePlayer(DIRECTIONS.SOUTH);

--- a/src/components/Game/movePlayer.ts
+++ b/src/components/Game/movePlayer.ts
@@ -1,6 +1,7 @@
 import { checkOnGameEvent, getUpdatedGameObjects } from '../../gameCore/controller';
 import CONSTANTS, { GAME_MODES, OBJECT_TYPES } from '../../gameCore/constants';
 import type { Direction } from '../../gameCore/constants';
+import type { GameObject } from '../../gameCore/types';
 import LEVELS from '../../gameCore/levels/LEVELS';
 import { useGameStore } from '../../stores/gameStore';
 import { useDialogsStore } from '../../stores/dialogsStore';
@@ -13,13 +14,29 @@ export const resetMoveThrottle = (): void => {
     lockedUntil = 0;
 };
 
+/** Открывает диалог события, если он ещё не прочитан. */
+const openEventDialog = (eventObject: GameObject): void => {
+    // TODO: OBJECT_TYPES.BATTLE — когда боевой экран перестанет быть заглушкой
+    if (eventObject.type !== OBJECT_TYPES.DIALOG || eventObject.dialogId === undefined) {
+        return;
+    }
+
+    const { alreadyReadIndexes, setCurrentDialog } = useDialogsStore.getState();
+    if (alreadyReadIndexes.includes(eventObject.dialogId)) {
+        return;
+    }
+
+    useGameStore.getState().setGameMode(GAME_MODES.SPEAKING);
+    setCurrentDialog(eventObject.dialogId);
+};
+
 /**
  * Единая точка входа для всех способов управления героем:
  * клавиатура, свайпы и экранный D-pad. Ходы троттлятся скоростью
  * анимации, состояние читается из сторов императивно.
  */
 export const movePlayer = (direction: Direction): void => {
-    const { level, gameObjects, gameMode, setGameMode, setGameObjects } = useGameStore.getState();
+    const { level, gameObjects, gameMode, setGameObjects } = useGameStore.getState();
     if (gameMode !== GAME_MODES.EXPLORING) {
         return;
     }
@@ -28,26 +45,33 @@ export const movePlayer = (direction: Direction): void => {
     if (now < lockedUntil) {
         return;
     }
-    lockedUntil = now + CONSTANTS.GAME_ANIMATE_SPEED;
+
+    const levelData = LEVELS[level];
+    if (!levelData) {
+        return;
+    }
 
     // обновить данные по всем игровым объектам на уровне
-    const updatedGameObjects = getUpdatedGameObjects(
+    const { newGameObjects, info } = getUpdatedGameObjects(
         gameObjects,
         { type: 'move', direction },
-        LEVELS[level],
+        levelData,
     );
 
-    const event = checkOnGameEvent(updatedGameObjects.newGameObjects);
-    const { alreadyReadIndexes, setCurrentDialog } = useDialogsStore.getState();
-    if (
-        event.isGameEvent &&
-        event.eventObject !== null &&
-        event.eventObject.type === OBJECT_TYPES.DIALOG &&
-        event.eventObject.dialogId !== undefined &&
-        !alreadyReadIndexes.includes(event.eventObject.dialogId)
-    ) {
-        setGameMode(GAME_MODES.SPEAKING);
-        setCurrentDialog(event.eventObject.dialogId);
+    if (info.heroChangedPosition) {
+        // троттлим только реальные перемещения: у них есть анимация сдвига,
+        // которую нельзя прерывать. Поворот на месте (упёрлись в стену)
+        // мгновенный, глушить из-за него следующее нажатие незачем
+        lockedUntil = now + CONSTANTS.GAME_ANIMATE_SPEED;
+
+        // события срабатывают только при заходе на клетку: иначе диалог
+        // открывался бы заново на каждый ход в стену, пока герой стоит
+        // на триггере
+        const { eventObject } = checkOnGameEvent(newGameObjects);
+        if (eventObject !== null) {
+            openEventDialog(eventObject);
+        }
     }
-    setGameObjects(updatedGameObjects.newGameObjects);
+
+    setGameObjects(newGameObjects);
 };

--- a/src/gameCore/controller.test.ts
+++ b/src/gameCore/controller.test.ts
@@ -80,6 +80,20 @@ describe('isWalkable', () => {
         expect(isWalkable({ x: 0, y: 0 }, level.levelMap, level.levelAssets)).toBe(true);
         expect(isWalkable({ x: 3, y: 2 }, level.levelMap, level.levelAssets)).toBe(false);
     });
+
+    it('считает непроходимой клетку вне карты', () => {
+        const level = makeLevel();
+        expect(isWalkable({ x: -1, y: 0 }, level.levelMap, level.levelAssets)).toBe(false);
+        expect(isWalkable({ x: 0, y: CONSTANTS.MAP_ROWS }, level.levelMap, level.levelAssets)).toBe(
+            false,
+        );
+    });
+
+    it('считает непроходимым тайл, которого нет в ассетах уровня', () => {
+        const level = makeLevel();
+        level.levelMap[0][0] = 42;
+        expect(isWalkable({ x: 0, y: 0 }, level.levelMap, level.levelAssets)).toBe(false);
+    });
 });
 
 describe('getUpdatedGameObjects', () => {
@@ -179,6 +193,16 @@ describe('getUpdatedGameObjects', () => {
             expect(newGameObjects[0].walkIndex).toBe(2);
         });
 
+        it('не продвигается, когда герой упёрся в стену', () => {
+            const hero = makeHero({ x: 5, y: 5 }, { walkIndex: 1, prevDirection: DIRECTIONS.EAST });
+            const { newGameObjects } = getUpdatedGameObjects(
+                [hero],
+                { type: 'move', direction: DIRECTIONS.EAST },
+                makeLevel([{ x: 6, y: 5 }]),
+            );
+            expect(newGameObjects[0].walkIndex).toBe(1);
+        });
+
         it('зацикливается после последней фазы', () => {
             const hero = makeHero(
                 { x: 5, y: 5 },
@@ -204,7 +228,6 @@ describe('checkOnGameEvent', () => {
 
         const result = checkOnGameEvent([hero, trigger]);
 
-        expect(result.isGameEvent).toBe(true);
         expect(result.eventObject).toBe(trigger);
     });
 
@@ -212,20 +235,17 @@ describe('checkOnGameEvent', () => {
         const hero = makeHero({ x: 0, y: 0 });
         const trigger = makeHero({ x: 2, y: 1 }, { id: 4, type: OBJECT_TYPES.DIALOG, sprite: '' });
 
-        expect(checkOnGameEvent([hero, trigger])).toEqual({
-            isGameEvent: false,
-            eventObject: null,
-        });
+        expect(checkOnGameEvent([hero, trigger])).toEqual({ eventObject: null });
     });
 
     it('игнорирует несобытийные объекты на клетке героя', () => {
         const hero = makeHero({ x: 3, y: 3 });
         const chest = makeHero({ x: 3, y: 3 }, { id: 2, type: OBJECT_TYPES.TREASURE_CHEST });
 
-        expect(checkOnGameEvent([hero, chest]).isGameEvent).toBe(false);
+        expect(checkOnGameEvent([hero, chest]).eventObject).toBeNull();
     });
 
     it('возвращает false, если героя нет среди объектов', () => {
-        expect(checkOnGameEvent([])).toEqual({ isGameEvent: false, eventObject: null });
+        expect(checkOnGameEvent([])).toEqual({ eventObject: null });
     });
 });

--- a/src/gameCore/controller.ts
+++ b/src/gameCore/controller.ts
@@ -48,6 +48,7 @@ const calculateWalkIndex = (gameObject: GameObject, direction: Direction): numbe
 export interface GameTickResult {
     newGameObjects: GameObject[];
     info: {
+        /** герой действительно перешёл на другую клетку (а не упёрся) */
         heroChangedPosition: boolean;
     };
 }
@@ -61,7 +62,7 @@ export const getUpdatedGameObjects = (
     action: GameAction,
     level: Level,
 ): GameTickResult => {
-    let heroChangedPosition = true;
+    let heroChangedPosition = false;
 
     const newGameObjects = gameObjects.map((obj) => {
         switch (action.type) {
@@ -76,15 +77,19 @@ export const getUpdatedGameObjects = (
                 const positionChanged =
                     canMove && (newCoords.x !== obj.coords.x || newCoords.y !== obj.coords.y);
 
-                if (!positionChanged) {
-                    heroChangedPosition = false;
+                if (positionChanged) {
+                    heroChangedPosition = true;
                 }
 
                 return {
                     ...obj,
                     currentDirection: action.direction,
                     prevDirection: action.direction,
-                    walkIndex: calculateWalkIndex(obj, action.direction),
+                    // фаза ходьбы продвигается только на реальном шаге: упёршись
+                    // в стену, герой поворачивается, а не топчется на месте
+                    walkIndex: positionChanged
+                        ? calculateWalkIndex(obj, action.direction)
+                        : obj.walkIndex,
                     coords: positionChanged ? newCoords : obj.coords,
                 };
             }
@@ -102,12 +107,13 @@ export const getUpdatedGameObjects = (
 };
 
 /**
- * Ищет событийный объект (диалог, битва) на клетке героя.
+ * Ищет событийный объект (диалог, битва) на клетке героя,
+ * либо null, если события нет.
  */
 export const checkOnGameEvent = (gameObjects: GameObject[]): GameEventCheck => {
     const hero = gameObjects.find((obj) => obj.type === OBJECT_TYPES.HERO);
     if (!hero) {
-        return { isGameEvent: false, eventObject: null };
+        return { eventObject: null };
     }
     const heroPos = hero.coords;
     const eventObject = gameObjects.find(
@@ -116,16 +122,22 @@ export const checkOnGameEvent = (gameObjects: GameObject[]): GameEventCheck => {
             obj.coords.x === heroPos.x &&
             obj.coords.y === heroPos.y,
     );
-    return {
-        isGameEvent: eventObject !== undefined,
-        eventObject: eventObject ?? null,
-    };
+    return { eventObject: eventObject ?? null };
 };
 
+/**
+ * Проходима ли клетка. Клетка вне карты и клетка со ссылкой на неизвестный
+ * тайл считаются непроходимыми: битые данные уровня должны упирать героя
+ * в стену, а не ронять игровой цикл.
+ */
 export const isWalkable = (
     coords: Coords,
     levelMap: number[][],
     levelAssets: Record<number, TileAsset>,
 ): boolean => {
-    return levelAssets[levelMap[coords.y][coords.x]].walkable;
+    const tileId = levelMap[coords.y]?.[coords.x];
+    if (tileId === undefined) {
+        return false;
+    }
+    return levelAssets[tileId]?.walkable === true;
 };

--- a/src/gameCore/types.ts
+++ b/src/gameCore/types.ts
@@ -63,6 +63,5 @@ export type GameAction = {
 };
 
 export interface GameEventCheck {
-    isGameEvent: boolean;
     eventObject: GameObject | null;
 }

--- a/src/stores/dialogsStore.ts
+++ b/src/stores/dialogsStore.ts
@@ -45,7 +45,8 @@ export const useDialogsStore = create<DialogsStore>()(
             addReadDialog: (dialogId) =>
                 set(
                     (state) => ({
-                        alreadyReadIndexes: state.dialogList[dialogId].isDisposable
+                        // ?. — закрытие диалога не должно падать на неизвестном id
+                        alreadyReadIndexes: state.dialogList[dialogId]?.isDisposable
                             ? [...state.alreadyReadIndexes, dialogId]
                             : state.alreadyReadIndexes,
                         currentDialogId: 0,


### PR DESCRIPTION
## Что сделано

### `heroChangedPosition` считался и выбрасывался

`getUpdatedGameObjects` всегда возвращал `info.heroChangedPosition`, но `movePlayer` его игнорировал и вызывал `checkOnGameEvent` после **любого** хода. Стоя на триггере диалога и упираясь в стену, игрок переоткрывал этот диалог на каждое нажатие. Сейчас не видно только потому, что единственный диалог в данных уровня одноразовый. Флаг существует ровно для этого — теперь он используется.

### Заблокированный ход съедал ввод

Троттлинг ставился до проверки проходимости, поэтому упирание в стену глушило следующие 300 мс ввода. Заметно, когда поворачиваешься к стене и сразу идёшь в другую сторону.

Теперь троттлятся только реальные перемещения — именно им принадлежит анимация сдвига, которую нельзя обрывать. Для консистентности `walkIndex` тоже больше не продвигается на заблокированном ходу: герой поворачивается лицом к стене, а не «шагает» на месте. **Это изменение видимого поведения** — если топтание у стены было задумано как фича, скажи, откачу именно эту часть.

### Ввод в диалоге был размазан по двум компонентам

`Dialog` и `DialogBox` оба слушали Enter: первый листал фразу, второй допечатывал текст. Работало только за счёт того, что устаревшее замыкание `typing` в `Dialog` заставляло его выйти раньше — любой рефакторинг это бы сломал.

Логика продвижения целиком переехала в `Dialog`, а `DialogBox` стал презентационным (без подписок на стор и слушателей). Побочно исправилось: уходящая фраза больше не обнуляет напечатанный текст посреди анимации ухода — печатается только текущий бокс.

### Живучесть на битых данных

Чтобы неполные данные уровня деградировали, а не роняли игровой цикл:

- `isWalkable` считает клетку вне карты и ссылку на неизвестный тайл непроходимыми (было — `TypeError`);
- `LEVELS[level]` проверяется перед использованием в `movePlayer`, `GameContainer` и `WorldMapContainer`;
- `addReadDialog` переживает неизвестный id диалога.

Плюс `checkOnGameEvent` больше не возвращает избыточный `isGameEvent` — `eventObject !== null` говорит то же самое.

## Как проверить

```sh
npm test && npm start
```

1. **Стена не глушит ввод:** герой на (0,0), нажать «влево» (некуда) и сразу «вниз» — шаг вниз происходит, а не проглатывается.
2. **Диалог не переоткрывается:** дойти до (2,1), пролистать диалог, затем нажимать «вверх» (там стена) — диалог не всплывает снова.
3. **Диалог работает как раньше:** Enter/тап допечатывает фразу, следующий Enter/тап листает, на последней — закрывает.

Все три сценария прогнал в браузере, ошибок в консоли нет.

## Чеклист

- [x] `npm run lint` и `npm run format:check` проходят
- [x] `npm run typecheck` без ошибок
- [x] `npm test` зелёный (40 тестов, было 35)
- [x] Игра проверена в браузере, если менялись UI или игровая логика


---
_Generated by [Claude Code](https://claude.ai/code/session_01NdNTQdr3VG6yobzQrEegW9)_