### PR TITLE
Add jsdom test setup and cover the components that had no tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm run build         # typecheck + production build to dist/
 npm run preview       # serve the production build locally
 ```
 
-Tests are Vitest, co-located with the code (`src/**/*.test.ts`) — pure gameCore logic and Zustand stores need no DOM, so there is no jsdom setup; reset stores in `beforeEach` via `useXxxStore.setState(initialState, true)`. CI (`.github/workflows/ci.yml`) runs lint + format check + typecheck + tests + build on every push to master and on pull requests.
+Tests are Vitest, co-located with the code (`src/**/*.test.ts(x)`); reset stores in `beforeEach` via `useXxxStore.setState(initialState, true)`. The default environment is `node` — pure gameCore logic and Zustand stores need no DOM. Component tests opt into jsdom with a `// @vitest-environment jsdom` docblock on the first line and render via `@testing-library/react`; `src/test/setup.ts` unmounts them between cases. Note that `@testing-library/jest-dom` is not installed, so assert on plain DOM (`element.textContent`) rather than matchers like `toHaveTextContent`. `movePlayer` throttles on `Date.now()`, which `vi.useFakeTimers()` also controls, so `vi.advanceTimersByTime` steps the game loop as well as timers. CI (`.github/workflows/ci.yml`) runs lint + format check + typecheck + tests + build on every push to master and on pull requests.
 
 Releases are tag-driven: pushing a `v*` tag (e.g. `npm version minor && git push --follow-tags`) triggers `.github/workflows/release.yml`, which re-runs checks, builds, and publishes a GitHub Release with auto-generated notes and a zipped `dist/`. Dependabot opens weekly PRs for npm (minor+patch grouped into one PR) and GitHub Actions updates.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "crawler-game",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "crawler-game",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "dependencies": {
                 "@react-spring/web": "^10.1.2",
                 "react": "^19.2.7",
@@ -16,6 +16,9 @@
             },
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
+                "@testing-library/dom": "^10.4.1",
+                "@testing-library/react": "^16.3.2",
+                "@testing-library/user-event": "^14.6.1",
                 "@types/node": "^26.1.0",
                 "@types/react": "^19.2.17",
                 "@types/react-dom": "^19.2.3",
@@ -26,6 +29,7 @@
                 "eslint-plugin-react-refresh": "^0.5.3",
                 "globals": "^17.7.0",
                 "husky": "^9.1.7",
+                "jsdom": "^29.1.1",
                 "lint-staged": "^17.0.8",
                 "prettier": "^3.9.4",
                 "sass": "^1.101.0",
@@ -37,6 +41,57 @@
             "engines": {
                 "node": ">=20.19"
             }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.7",
@@ -230,6 +285,16 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/template": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -276,6 +341,159 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+            "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+            "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.1.0",
+                "@csstools/css-calc": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+            "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@emnapi/core": {
@@ -438,6 +656,24 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+            "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@humanfs/core": {
@@ -1239,6 +1475,68 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.6.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+            "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=7.21.4"
+            }
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1249,6 +1547,13 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -1783,6 +2088,16 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1814,6 +2129,16 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/brace-expansion": {
@@ -1978,11 +2303,39 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/csstype": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -2002,12 +2355,29 @@
                 }
             }
         },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
@@ -2018,6 +2388,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.387",
@@ -2032,6 +2409,19 @@
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/environment": {
             "version": "1.1.0",
@@ -2475,6 +2865,19 @@
                 "hermes-estree": "0.25.1"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/husky": {
             "version": "9.1.7",
             "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -2557,6 +2960,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2570,6 +2980,57 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.1.11",
+                "@asamuzakjp/dom-selector": "^7.1.1",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.3.5",
+                "parse5": "^8.0.1",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.25.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -3044,6 +3505,16 @@
                 "yallist": "^3.0.2"
             }
         },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3053,6 +3524,13 @@
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/mimic-function": {
             "version": "5.0.1",
@@ -3214,6 +3692,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3316,6 +3807,44 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3346,6 +3875,13 @@
             "peerDependencies": {
                 "react": "^19.2.7"
             }
+        },
+        "node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/react-router": {
             "version": "7.18.1",
@@ -3397,6 +3933,16 @@
             "funding": {
                 "type": "individual",
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/restore-cursor": {
@@ -3476,6 +4022,19 @@
             },
             "optionalDependencies": {
                 "@parcel/watcher": "^2.4.1"
+            }
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
             }
         },
         "node_modules/scheduler": {
@@ -3627,6 +4186,13 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3669,6 +4235,52 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+            "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.4.9"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+            "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+            "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/ts-api-utils": {
@@ -3741,6 +4353,16 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -3959,6 +4581,54 @@
                 }
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4019,6 +4689,23 @@
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/yallist": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -25,6 +28,7 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
         "husky": "^9.1.7",
+        "jsdom": "^29.1.1",
         "lint-staged": "^17.0.8",
         "prettier": "^3.9.4",
         "sass": "^1.101.0",

--- a/src/components/Game/Dialog/Dialog.test.tsx
+++ b/src/components/Game/Dialog/Dialog.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Dialog from './Dialog';
+import { GAME_MODES, SPEAKER_ROLES } from '../../../gameCore/constants';
+import type { LevelDialogs } from '../../../gameCore/types';
+import { useGameStore } from '../../../stores/gameStore';
+import { useDialogsStore } from '../../../stores/dialogsStore';
+
+const DIALOGS: LevelDialogs = {
+    speakersData: [
+        { name: 'Leia', role: SPEAKER_ROLES.HERO, sprite: 'leia.png' },
+        { name: 'Grimm', role: SPEAKER_ROLES.ENEMY, sprite: 'grimm.png' },
+    ],
+    dialogList: {
+        1: {
+            isDisposable: true,
+            phrases: [
+                { speaker: 'Leia', text: 'первая фраза' },
+                { speaker: 'Grimm', text: 'вторая фраза' },
+            ],
+        },
+    },
+};
+
+const initialGameState = useGameStore.getState();
+const initialDialogsState = useDialogsStore.getState();
+
+/** Нажатие Enter по window — так же, как это делает игрок. */
+const pressEnter = () => act(() => void fireEvent.keyDown(window, { key: 'Enter' }));
+
+describe('Dialog', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        useGameStore.setState(initialGameState, true);
+        useDialogsStore.setState(initialDialogsState, true);
+        useDialogsStore.getState().loadDialogs(DIALOGS);
+        useDialogsStore.getState().setCurrentDialog(1);
+    });
+
+    /** Промотать таймеры печати, чтобы фраза напечаталась целиком. */
+    const finishTypewriter = () => act(() => void vi.advanceTimersByTime(2000));
+
+    it('печатает первую фразу и её говорящего', () => {
+        render(<Dialog />);
+
+        expect(screen.getByRole('heading').textContent).toBe('Leia');
+        finishTypewriter();
+        expect(screen.getByText('первая фраза')).toBeTruthy();
+    });
+
+    it('Enter допечатывает фразу, не листая её', () => {
+        render(<Dialog />);
+
+        // до нажатия текст ещё печатается — виден курсор
+        pressEnter();
+
+        expect(useDialogsStore.getState().typing).toBe(false);
+        expect(screen.getByText('первая фраза')).toBeTruthy();
+        expect(screen.getByRole('heading').textContent).toBe('Leia');
+    });
+
+    it('следующий Enter листает на вторую фразу', () => {
+        render(<Dialog />);
+
+        pressEnter(); // допечатать
+        pressEnter(); // листнуть
+        finishTypewriter();
+
+        expect(screen.getByText('вторая фраза')).toBeTruthy();
+        expect(useGameStore.getState().gameMode).toBe(GAME_MODES.EXPLORING);
+    });
+
+    it('на последней фразе возвращает режим исследования и помечает диалог прочитанным', () => {
+        useGameStore.getState().setGameMode(GAME_MODES.SPEAKING);
+        render(<Dialog />);
+
+        pressEnter(); // допечатать первую
+        pressEnter(); // листнуть на вторую
+        pressEnter(); // допечатать вторую
+        pressEnter(); // закрыть
+
+        expect(useGameStore.getState().gameMode).toBe(GAME_MODES.EXPLORING);
+        expect(useDialogsStore.getState().alreadyReadIndexes).toContain(1);
+        expect(useDialogsStore.getState().currentDialogId).toBe(0);
+    });
+
+    it('тап по диалогу продвигает его так же, как Enter', () => {
+        render(<Dialog />);
+
+        act(() => void fireEvent.click(screen.getByText('Leia')));
+
+        expect(useDialogsStore.getState().typing).toBe(false);
+    });
+
+    it('снимает слушатель клавиатуры при размонтировании', () => {
+        const { unmount } = render(<Dialog />);
+        pressEnter();
+        unmount();
+
+        useDialogsStore.getState().setTyping(true);
+        pressEnter();
+
+        // после размонтирования нажатия больше ничего не переключают
+        expect(useDialogsStore.getState().typing).toBe(true);
+    });
+});

--- a/src/components/Game/TouchControls/TouchControls.test.tsx
+++ b/src/components/Game/TouchControls/TouchControls.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import TouchControls from './TouchControls';
+import CONSTANTS, { GAME_MODES, OBJECT_TYPES } from '../../../gameCore/constants';
+import LEVELS from '../../../gameCore/levels/LEVELS';
+import { useGameStore } from '../../../stores/gameStore';
+import { useDialogsStore } from '../../../stores/dialogsStore';
+import { resetMoveThrottle } from '../movePlayer';
+
+const initialGameState = useGameStore.getState();
+const initialDialogsState = useDialogsStore.getState();
+
+const heroCoords = () =>
+    useGameStore.getState().gameObjects.find((obj) => obj.type === OBJECT_TYPES.HERO)?.coords;
+
+/** Удержание кнопки: pointerdown без последующего pointerup. */
+const holdButton = (label: string) =>
+    act(() => void fireEvent.pointerDown(screen.getByRole('button', { name: label })));
+
+const releaseButton = (label: string) =>
+    act(() => void fireEvent.pointerUp(screen.getByRole('button', { name: label })));
+
+/** Прокрутить n шагов автоповтора. */
+const advanceSteps = (n: number) =>
+    act(() => void vi.advanceTimersByTime(CONSTANTS.GAME_ANIMATE_SPEED * n));
+
+describe('TouchControls', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        useGameStore.setState(initialGameState, true);
+        useDialogsStore.setState(initialDialogsState, true);
+        useGameStore.getState().loadLevel(LEVELS[1]);
+        useDialogsStore.getState().loadDialogs(LEVELS[1].dialogs);
+        resetMoveThrottle();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('рисует все четыре направления', () => {
+        render(<TouchControls />);
+
+        for (const label of ['Вверх', 'Вниз', 'Влево', 'Вправо']) {
+            expect(screen.getByRole('button', { name: label })).toBeTruthy();
+        }
+    });
+
+    it('нажатие сразу делает один ход', () => {
+        render(<TouchControls />);
+
+        holdButton('Вниз');
+
+        expect(heroCoords()).toEqual({ x: 0, y: 1 });
+    });
+
+    it('удержание повторяет ходы с шагом анимации', () => {
+        render(<TouchControls />);
+
+        holdButton('Вниз');
+        advanceSteps(2);
+
+        expect(heroCoords()).toEqual({ x: 0, y: 3 });
+    });
+
+    it('отпускание кнопки прекращает автоповтор', () => {
+        render(<TouchControls />);
+
+        holdButton('Вниз');
+        releaseButton('Вниз');
+        advanceSteps(5);
+
+        expect(heroCoords()).toEqual({ x: 0, y: 1 });
+    });
+
+    it('прячется вне режима исследования', () => {
+        useGameStore.getState().setGameMode(GAME_MODES.SPEAKING);
+
+        render(<TouchControls />);
+
+        expect(screen.queryByRole('button', { name: 'Вниз' })).toBeNull();
+    });
+
+    it('глушит автоповтор, когда ход открыл диалог и кнопка исчезла до pointerup', () => {
+        render(<TouchControls />);
+
+        // (0,0) -> (0,1) -> (1,1) -> (2,1): на последней клетке триггер диалога
+        holdButton('Вниз');
+        releaseButton('Вниз');
+        resetMoveThrottle();
+        holdButton('Вправо');
+        advanceSteps(1);
+
+        // режим сменился на SPEAKING, кнопка размонтировалась без pointerup
+        expect(useGameStore.getState().gameMode).toBe(GAME_MODES.SPEAKING);
+        expect(heroCoords()).toEqual({ x: 2, y: 1 });
+
+        // автоповтор не должен продолжать двигать героя
+        advanceSteps(5);
+        expect(heroCoords()).toEqual({ x: 2, y: 1 });
+    });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,13 @@
+import { afterEach } from 'vitest';
+
+// По умолчанию тесты идут в node-окружении: чистая логика gameCore и сторы
+// в DOM не нуждаются. Компонентные тесты просят jsdom докблоком
+// `@vitest-environment jsdom`, и только для них нужно размонтировать
+// отрендеренные деревья между кейсами.
+afterEach(async () => {
+    if (typeof document === 'undefined') {
+        return;
+    }
+    const { cleanup } = await import('@testing-library/react');
+    cleanup();
+});

--- a/src/utils/preloadImages.test.ts
+++ b/src/utils/preloadImages.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { preloadImages } from './preloadImages';
+
+/**
+ * jsdom не грузит ресурсы, а `new Image()` не попадает в документ, поэтому
+ * подменяем конструктор: так тест держит ссылки на созданные картинки
+ * и сам решает, когда каждая из них «загрузилась».
+ */
+class FakeImage {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    decode?: () => Promise<void>;
+
+    set src(_value: string) {
+        created.push(this);
+    }
+}
+
+let created: FakeImage[] = [];
+
+const withDecode = () => {
+    for (const image of created) {
+        image.decode = () => Promise.resolve();
+    }
+};
+
+describe('preloadImages', () => {
+    beforeEach(() => {
+        created = [];
+        vi.useFakeTimers();
+        vi.stubGlobal('Image', FakeImage);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it('резолвится по таймауту, если картинка так и не загрузилась', async () => {
+        // главное свойство: медленная сеть портит вид, но не запирает
+        // игрока в прелоадере навсегда
+        const pending = preloadImages(['never-loads.png'], 100);
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        await expect(pending).resolves.toBeUndefined();
+    });
+
+    it('резолвится, когда все картинки загрузились', async () => {
+        const pending = preloadImages(['a.png', 'b.png'], 10_000);
+        expect(created).toHaveLength(2);
+
+        for (const image of created) {
+            image.onload?.();
+        }
+
+        await expect(pending).resolves.toBeUndefined();
+    });
+
+    it('ждёт декодирования там, где оно поддерживается', async () => {
+        const pending = preloadImages(['a.png'], 10_000);
+        withDecode();
+
+        for (const image of created) {
+            image.onload?.();
+        }
+
+        await expect(pending).resolves.toBeUndefined();
+    });
+
+    it('не считает битую картинку поводом остановить загрузку', async () => {
+        const pending = preloadImages(['broken.png', 'ok.png'], 10_000);
+
+        created[0].onerror?.();
+        created[1].onload?.();
+
+        await expect(pending).resolves.toBeUndefined();
+    });
+
+    it('не резолвится, пока загрузилась только часть картинок', async () => {
+        const settled = vi.fn();
+        preloadImages(['a.png', 'b.png'], 10_000).then(settled);
+
+        created[0].onload?.();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(settled).not.toHaveBeenCalled();
+    });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig } from 'vite';
+// defineConfig из vitest/config, а не из vite: только он знает про секцию test
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
@@ -8,5 +9,11 @@ export default defineConfig({
     plugins: [react()],
     server: {
         port: 3000,
+    },
+    test: {
+        // node по умолчанию — чистой логике и сторам DOM не нужен;
+        // компонентные тесты включают jsdom докблоком @vitest-environment
+        environment: 'node',
+        setupFiles: ['./src/test/setup.ts'],
     },
 });


### PR DESCRIPTION
## Что сделано

`gameCore` и сторы были покрыты тестами, компоненты — нет вообще. Без покрытия оставался самый хрупкий код: обработка Enter/тапа в диалоге и автоповтор D-pad — оба жонглируют таймерами, записью в стор и размонтированием.

### Настройка

Окружением по умолчанию остаётся `node`, чтобы существующие тесты чистой логики не тащили DOM и не замедлялись. Компонентные тесты включают jsdom по файлу докблоком `// @vitest-environment jsdom`; `src/test/setup.ts` размонтирует отрендеренные деревья между кейсами и ничего не делает там, где документа нет.

`@testing-library/jest-dom` осознанно не ставил — матчеры вроде `toHaveTextContent` заменяются проверками обычного DOM (`element.textContent`), это на одну зависимость меньше.

### Новое покрытие (17 кейсов, 40 → 57)

**`Dialog`** — печать фразы, Enter именно допечатывает её (а не перескакивает через), листание на следующую, закрытие с пометкой «прочитано» на последней, тап работает как Enter, слушатель клавиатуры снимается при размонтировании.

**`TouchControls`** — мгновенный шаг по нажатию, повтор при удержании с шагом анимации, остановка повтора по отпусканию, скрытие вне `EXPLORING` и тот самый случай, ради которого в компоненте есть отдельный эффект: ход, открывающий диалог, размонтирует кнопку **до** `pointerup`, поэтому интервал автоповтора нужно глушить принудительно.

**`preloadImages`** — резолв по завершении, устойчивость к битому файлу, ожидание `decode()` где он есть, ожидание всех картинок (а не первой) и резолв по таймауту, чтобы зависшая загрузка не запирала игрока в прелоадере.

Полезно знать при написании новых тестов: `movePlayer` троттлит по `Date.now()`, которым `vi.useFakeTimers()` тоже управляет, поэтому `vi.advanceTimersByTime` продвигает и игровой цикл, а не только таймеры. Записал это в CLAUDE.md вместе с описанием настройки.

`vite.config.ts` теперь берёт `defineConfig` из `vitest/config`: у вариантa из `vite` нет ключа `test`, и `tsc` это отклонял.

## Как проверить

```sh
npm test        # 57 тестов
npm run typecheck
```

## Чеклист

- [x] `npm run lint` и `npm run format:check` проходят
- [x] `npm run typecheck` без ошибок
- [x] `npm test` зелёный (57 тестов, было 40)
- [x] Игра проверена в браузере, если менялись UI или игровая логика — продакшен-код не менялся, только тесты и конфиг


---
_Generated by [Claude Code](https://claude.ai/code/session_01NdNTQdr3VG6yobzQrEegW9)_